### PR TITLE
Allow rewriting of url per host

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"io"
 	"reflect"
 	"regexp"


### PR DESCRIPTION
The format is --output-http="foo.bar|/a:/b" or, in case of limit options, --output-http="foo.bar|40|/a:/b".

This allows for different rewrite rules for different hosts, for example when your staging environment has a different url schema than your development environment

Currently only implemented for http output

This works, however what else is needed to get this merged upstream?