### PR TITLE
Properly return from errors from ReadRequest

### DIFF
--- a/output_http.go
+++ b/output_http.go
@@ -34,6 +34,10 @@ func ParseRequest(data []byte) (request *http.Request, err error) {
 
 	request, err = http.ReadRequest(reader)
 
+	if (err != nil) {
+		return
+	}
+
 	if request.Method == "POST" {
 		body, _ := ioutil.ReadAll(reader)
 		bodyBuf := bytes.NewBuffer(body)


### PR DESCRIPTION
If we return here, the error will be properly handled in `sendRequest`.