### PR TITLE
Properly handle errors on input sockets

### DIFF
--- a/input_tcp.go
+++ b/input_tcp.go
@@ -62,6 +62,12 @@ func (i *TCPInput) handleConnection(conn net.Conn) {
 
 	for {
 		buf, err := reader.ReadBytes('¶')
+		if err == io.EOF {
+			return
+		} else if err != nil {
+			log.Println("Unexpected error in input tcp connection", err)
+			return
+		}
 		buf_len := len(buf)
 		if buf_len > 0 {
 			new_buf_len := len(buf) - 2
@@ -69,11 +75,6 @@ func (i *TCPInput) handleConnection(conn net.Conn) {
 				new_buf := make([]byte, new_buf_len)
 				copy(new_buf, buf[:new_buf_len])
 				i.data <- new_buf
-				if err != nil {
-					if err != io.EOF {
-						log.Printf("error: %s\n", err)
-					}
-				}
 			}
 		}
 	}


### PR DESCRIPTION
`buf` is of length 0, so you never make it into the loop to handle the errors. This means you end up in a tight loop calling `ReadBytes` and always getting back `io.EOF` and 0 bytes.