### PR TITLE
Prevent crash if no permissions on port

### DIFF
--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -61,11 +61,12 @@ func (t *Listener) listen() {
 
 func (t *Listener) readRAWSocket() {
     conn, e := net.ListenPacket("ip4:tcp", t.addr)
-    defer conn.Close()
 
     if e != nil {
         log.Fatal(e)
     }
+
+    defer conn.Close()
 
     buf := make([]byte, 4096*2)
 


### PR DESCRIPTION
This fix prevents Gor from crashing at startup if run without proper
permissions for listening on specified port.