### PR TITLE
Modify input_tcp_test to test new connection closing

### DIFF
--- a/input_tcp.go
+++ b/input_tcp.go
@@ -5,21 +5,24 @@ import (
 	"io"
 	"log"
 	"net"
+	"sync/atomic"
 )
 
 // Can be tested using nc tool:
 //    echo "asdad" | nc 127.0.0.1 27017
 //
 type TCPInput struct {
-	data     chan []byte
-	address  string
-	listener net.Listener
+	data            chan []byte
+	address         string
+	listener        net.Listener
+	openConnections int32
 }
 
 func NewTCPInput(address string) (i *TCPInput) {
 	i = new(TCPInput)
 	i.data = make(chan []byte)
 	i.address = address
+	atomic.StoreInt32(&i.openConnections, 0)
 
 	i.listen(address)
 
@@ -58,15 +61,17 @@ func (i *TCPInput) listen(address string) {
 func (i *TCPInput) handleConnection(conn net.Conn) {
 	defer conn.Close()
 
+	atomic.AddInt32(&i.openConnections, 1)
+
 	reader := bufio.NewReader(conn)
 
 	for {
 		buf, err := reader.ReadBytes('¶')
 		if err == io.EOF {
-			return
+			break
 		} else if err != nil {
 			log.Println("Unexpected error in input tcp connection", err)
-			return
+			break
 		}
 		buf_len := len(buf)
 		if buf_len > 0 {
@@ -78,8 +83,14 @@ func (i *TCPInput) handleConnection(conn net.Conn) {
 			}
 		}
 	}
+
+	atomic.AddInt32(&i.openConnections, -1)
 }
 
 func (i *TCPInput) String() string {
 	return "TCP input: " + i.address
+}
+
+func (i *TCPInput) connections() int32 {
+	return atomic.LoadInt32(&i.openConnections)
 }

--- a/input_tcp_test.go
+++ b/input_tcp_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestTCPInput(t *testing.T) {
@@ -45,6 +46,25 @@ func TestTCPInput(t *testing.T) {
 	}
 
 	wg.Wait()
+
+	if input.connections() != 1 {
+		log.Fatal("Incorrect number of connections, expected 1, got %d",
+			input.connections())
+	}
+
+	conn.Close()
+
+	i := 0
+	iterations := 10
+	for ; i < iterations; i++ {
+		if input.connections() == 0 {
+			break
+		}
+		time.Sleep(time.Second / time.Duration(iterations))
+	}
+	if i == iterations {
+		log.Fatal("Connection did not close cleanly")
+	}
 
 	close(quit)
 }


### PR DESCRIPTION
Modify the tests to better test the functionality added in #141 

@buger I'm not terribly familiar with testing in Go, so this might not be the best way to do this. Comments, of course, welcome.

