### PR TITLE
fix Issue 136 - chunked transfer bodies are reencoded

### DIFF
--- a/output_http.go
+++ b/output_http.go
@@ -38,6 +38,13 @@ func ParseRequest(data []byte) (request *http.Request, err error) {
 		return
 	}
 
+	// preserve chunked encoding (see #136)
+	for _, encoding := range request.TransferEncoding {
+		if encoding == "chunked" {
+			return
+		}
+	}
+
 	if request.Method == "POST" {
 		body, _ := ioutil.ReadAll(reader)
 		bodyBuf := bytes.NewBuffer(body)

--- a/output_http_test.go
+++ b/output_http_test.go
@@ -67,7 +67,7 @@ func TestHTTPOutput(t *testing.T) {
 			defer req.Body.Close()
 			body, _ := ioutil.ReadAll(req.Body)
 
-			if string(body) != "a=1&b=2\r\n\r\n" {
+			if string(body) != "xyzxyzxyz" {
 				buf, _ := httputil.DumpRequest(req, true)
 				t.Error("Wrong POST body:", string(buf))
 			}
@@ -84,9 +84,10 @@ func TestHTTPOutput(t *testing.T) {
 	go Start(quit)
 
 	for i := 0; i < 100; i++ {
-		wg.Add(2)
+		wg.Add(3)
 		input.EmitPOST()
-		input.EmitOPTIONS()
+		input.EmitChunkedPOST()
+		input.EmitOPTIONS() // filtered out
 		input.EmitGET()
 	}
 

--- a/test_input.go
+++ b/test_input.go
@@ -28,7 +28,11 @@ func (i *TestInput) EmitGET() {
 }
 
 func (i *TestInput) EmitPOST() {
-	i.data <- []byte("POST /pub/WWW/ HTTP/1.1\nHost: www.w3.org\r\n\r\na=1&b=2\r\n\r\n")
+	i.data <- []byte("POST /pub/WWW/ HTTP/1.1\nHost: www.w3.org\r\n\r\nxyzxyzxyz")
+}
+
+func (i *TestInput) EmitChunkedPOST() {
+	i.data <- []byte("POST /pub/WWW/ HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n9\r\nxyzxyzxyz\r\n0\r\n\r\n")
 }
 
 func (i *TestInput) EmitFile() {


### PR DESCRIPTION
- preserve transfer-encoding: chunked bodies by not
  computing and setting the content length