### PR TITLE
Fix alignment crash on i386

### DIFF
--- a/output_http.go
+++ b/output_http.go
@@ -51,13 +51,17 @@ func ParseRequest(data []byte) (request *http.Request, err error) {
 const InitialDynamicWorkers = 10
 
 type HTTPOutput struct {
+	// Keep this as first element of struct because it guarantees 64bit
+	// alignment. atomic.* functions crash on 32bit machines if operand is not
+	// aligned at 64bit. See https://github.com/golang/go/issues/599
+	activeWorkers int64
+
 	address string
 	limit   int
 	queue   chan []byte
 
 	redirectLimit int
 
-	activeWorkers int64
 	needWorker    chan int
 
 	urlRegexp            HTTPUrlRegexp


### PR DESCRIPTION
This fixes a crash on 32bit machines which looks like this:

```
# ./go --input-raw :80 --output-http 'http://example.com' -verbose
Version: 0.9.2
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x1 pc=0x818acfc]

goroutine 11 [running]:
sync/atomic.AddUint64(0x18640394, 0x1, 0x0, 0x0, 0x0)
        /usr/local/go/src/sync/atomic/asm_386.s:118 +0xc
main.(*HTTPOutput).Worker(0x18640380)
        <snip>/go/src/github.com/buger/gor/output_http.go:140 +0xe1
created by main.(*HTTPOutput).WorkerMaster
        <snip>/go/src/github.com/buger/gor/output_http.go:123 +0x6c
```

This happens because because of an explicit check for 64bit alignment added to go by [1]. The go compiler however does not guarantee this alignment as discussed in [2] and [3]. As a workaround this pull request moves `activeWorkers` to be the first element of the struct which is always aligned properly.

[1] https://code.google.com/p/go/source/detail?r=09cc9661f4ee29dca7da92ae8916cefded775bb5&path=/src/pkg/sync/atomic/asm_386.s
[2] https://github.com/golang/go/issues/599
[3] https://github.com/golang/go/issues/3799