### PR TITLE
Fix packet loss in heavy traffic

### DIFF
--- a/output_http.go
+++ b/output_http.go
@@ -194,7 +194,7 @@ func (o *HTTPOutput) sendRequest(client *http.Client, data []byte) {
 	request, err := ParseRequest(data)
 
 	if err != nil {
-		log.Println("Cannot parse request", string(data), err)
+		log.Println("Cannot parse request", string(data[0:32]), err)
 		return
 	}
 

--- a/raw_socket_listener/tcp_packet.go
+++ b/raw_socket_listener/tcp_packet.go
@@ -41,7 +41,7 @@ type TCPPacket struct {
 
 func ParseTCPPacket(addr net.Addr, b []byte) (p *TCPPacket) {
     p = &TCPPacket{Data: b}
-    p.ParseBasic()
+    p.Parse()
     p.Addr = addr
 
     return p
@@ -49,13 +49,17 @@ func ParseTCPPacket(addr net.Addr, b []byte) (p *TCPPacket) {
 
 // Parse TCP Packet, inspired by: https://github.com/miekg/pcap/blob/master/packet.go
 func (t *TCPPacket) Parse() {
-    t.ParseBasic()
     t.SrcPort = binary.BigEndian.Uint16(t.Data[0:2])
     t.DestPort = binary.BigEndian.Uint16(t.Data[2:4])
+    t.Seq = binary.BigEndian.Uint32(t.Data[4:8])
+    t.Ack = binary.BigEndian.Uint32(t.Data[8:12])
+    t.DataOffset = (t.Data[12] & 0xF0) >> 4
     t.Flags = binary.BigEndian.Uint16(t.Data[12:14]) & 0x1FF
     t.Window = binary.BigEndian.Uint16(t.Data[14:16])
     t.Checksum = binary.BigEndian.Uint16(t.Data[16:18])
     t.Urgent = binary.BigEndian.Uint16(t.Data[18:20])
+
+    t.Data = t.Data[t.DataOffset*4:]
 }
 
 // ParseBasic set of fields


### PR DESCRIPTION
In a testing of ~15MB/s net traffic, gor report "malformed http request" frequently(output http mode).
It turns out that it misses some packet of a relative large HTTP POST request. Examining the recv-Q by netstat -an --raw tells me that there is packet loss. 

This pull request fixes two issues:
1. Use goroutine in the raw socket listener to speedup receiving packets
2. A uinque TCPMessage id should be source-addr + source-port + ack