### PR TITLE
Handle Transfer-Encoding: chunked

### DIFF
--- a/output_http_test.go
+++ b/output_http_test.go
@@ -67,7 +67,7 @@ func TestHTTPOutput(t *testing.T) {
 			defer req.Body.Close()
 			body, _ := ioutil.ReadAll(req.Body)
 
-			if string(body) != "a=1&b=2\r\n\r\n" {
+			if string(body) != "a=1&b=2" {
 				buf, _ := httputil.DumpRequest(req, true)
 				t.Error("Wrong POST body:", string(buf))
 			}
@@ -89,6 +89,42 @@ func TestHTTPOutput(t *testing.T) {
 		input.EmitOPTIONS()
 		input.EmitGET()
 	}
+
+	wg.Wait()
+
+	close(quit)
+}
+
+func TestHTTPOutputChunkedEncoding(t *testing.T) {
+	wg := new(sync.WaitGroup)
+	quit := make(chan int)
+
+	input := NewTestInput()
+
+	headers := HTTPHeaders{HTTPHeader{"User-Agent", "Gor"}}
+	methods := HTTPMethods{"GET", "PUT", "POST"}
+
+	listener := startHTTP(func(req *http.Request) {
+		defer req.Body.Close()
+		body, _ := ioutil.ReadAll(req.Body)
+
+		if string(body) != "Wikipedia in\r\n\r\nchunks." {
+			buf, _ := httputil.DumpRequest(req, true)
+			t.Error("Wrong POST body:", buf, body, []byte("Wikipedia in\r\n\r\nchunks."))
+		}
+
+		wg.Done()
+	})
+
+	output := NewHTTPOutput(listener.Addr().String(), headers, methods, HTTPUrlRegexp{}, HTTPHeaderFilters{}, HTTPHeaderHashFilters{}, "", UrlRewriteMap{})
+
+	Plugins.Inputs = []io.Reader{input}
+	Plugins.Outputs = []io.Writer{output}
+
+	go Start(quit)
+
+	wg.Add(1)
+	input.EmitChunkedPOST()
 
 	wg.Wait()
 

--- a/test_input.go
+++ b/test_input.go
@@ -28,7 +28,11 @@ func (i *TestInput) EmitGET() {
 }
 
 func (i *TestInput) EmitPOST() {
-	i.data <- []byte("POST /pub/WWW/ HTTP/1.1\nHost: www.w3.org\r\n\r\na=1&b=2\r\n\r\n")
+	i.data <- []byte("POST /pub/WWW/ HTTP/1.1\nHost: www.w3.org\r\n\r\na=1&b=2")
+}
+
+func (i *TestInput) EmitChunkedPOST() {
+	i.data <- []byte("POST /pub/WWW/ HTTP/1.1\nHost: www.w3.org\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\ne\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n")
 }
 
 func (i *TestInput) EmitFile() {


### PR DESCRIPTION
Currently any request with chunked encoding will cause error. 
We have to manually detect such requests and use special body parser (included into httputils).