### PR TITLE
Fix Expect: 100-continue requests and refactor chunked encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ dtest:
 dfmt:
 	docker run -v `pwd`:/gopath/src/gor -t -i gor go fmt
 
+dvet:
+	docker run -v `pwd`:/gopath/src/gor -t -i gor go vet
+
 dbench:
 	docker run -v `pwd`:/gopath/src/gor -t -i gor go test -v -run NOT_EXISTING -bench HTTP
 

--- a/input_raw.go
+++ b/input_raw.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	raw "github.com/buger/gor/raw_socket_listener"
+	raw "gor/raw_socket_listener"
 	"log"
 	"net"
 	"strings"

--- a/input_raw.go
+++ b/input_raw.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	raw "gor/raw_socket_listener"
+	raw "github.com/buger/gor/raw_socket_listener"
 	"log"
 	"net"
 	"strings"

--- a/input_raw_test.go
+++ b/input_raw_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"io"
+	"io/ioutil"
+	"log"
 	"net/http"
+	"net/http/httputil"
+	"os/exec"
 	"strings"
 	"sync"
 	"testing"
@@ -31,6 +36,126 @@ func TestRAWInput(t *testing.T) {
 		wg.Add(1)
 		res, _ := http.Get("http://" + address)
 		res.Body.Close()
+	}
+
+	wg.Wait()
+
+	close(quit)
+}
+
+func TestInputRAW100Expect(t *testing.T) {
+	wg := new(sync.WaitGroup)
+	quit := make(chan int)
+
+	file_content, _ := ioutil.ReadFile("README.md")
+
+	// Origing and Replay server initialization
+	origin := startHTTP(func(req *http.Request) {
+		defer req.Body.Close()
+		ioutil.ReadAll(req.Body)
+
+		wg.Done()
+	})
+
+	origin_address := strings.Replace(origin.Addr().String(), "[::]", "127.0.0.1", -1)
+
+	input := NewRAWInput(origin_address)
+
+	// We will use it to get content of raw HTTP request
+	test_output := NewTestOutput(func(data []byte) {
+		if strings.Contains(string(data), "Expect: 100-continue") {
+			t.Error("Should not contain 100-continue header")
+		}
+		wg.Done()
+	})
+
+	listener := startHTTP(func(req *http.Request) {
+		defer req.Body.Close()
+		body, _ := ioutil.ReadAll(req.Body)
+
+		if !bytes.Equal(body, file_content) {
+			buf, _ := httputil.DumpRequest(req, true)
+			t.Error("Wrong POST body:", string(buf))
+		}
+
+		wg.Done()
+	})
+	replay_address := listener.Addr().String()
+
+	headers := HTTPHeaders{HTTPHeader{"User-Agent", "Gor"}}
+	methods := HTTPMethods{"GET", "PUT", "POST"}
+	http_output := NewHTTPOutput(replay_address, headers, methods, HTTPUrlRegexp{}, HTTPHeaderFilters{}, HTTPHeaderHashFilters{}, "", UrlRewriteMap{}, 0)
+
+	Plugins.Inputs = []io.Reader{input}
+	Plugins.Outputs = []io.Writer{test_output, http_output}
+
+	go Start(quit)
+
+	wg.Add(3)
+	curl := exec.Command("curl", "http://"+origin_address, "--data-binary", "@README.md")
+	err := curl.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	wg.Wait()
+	close(quit)
+}
+
+func TestInputRAWChunkedEncoding(t *testing.T) {
+	wg := new(sync.WaitGroup)
+	quit := make(chan int)
+
+	file_content, _ := ioutil.ReadFile("README.md")
+
+	// Origing and Replay server initialization
+	origin := startHTTP(func(req *http.Request) {
+		defer req.Body.Close()
+		ioutil.ReadAll(req.Body)
+
+		wg.Done()
+	})
+
+	origin_address := strings.Replace(origin.Addr().String(), "[::]", "127.0.0.1", -1)
+
+	input := NewRAWInput(origin_address)
+
+	// We will use it to get content of raw HTTP request
+	test_output := NewTestOutput(func(data []byte) {
+		if strings.Contains(string(data), "Expect: 100-continue") {
+			t.Error("Should not contain 100-continue header")
+		}
+		wg.Done()
+	})
+
+	listener := startHTTP(func(req *http.Request) {
+		defer req.Body.Close()
+		body, _ := ioutil.ReadAll(req.Body)
+
+		if !bytes.Equal(body, file_content) {
+			buf, _ := httputil.DumpRequest(req, true)
+			t.Error("Wrong POST body:", string(buf))
+		}
+
+		wg.Done()
+	})
+	replay_address := listener.Addr().String()
+
+	headers := HTTPHeaders{HTTPHeader{"User-Agent", "Gor"}}
+	methods := HTTPMethods{"GET", "PUT", "POST"}
+	http_output := NewHTTPOutput(replay_address, headers, methods, HTTPUrlRegexp{}, HTTPHeaderFilters{}, HTTPHeaderHashFilters{}, "", UrlRewriteMap{}, 0)
+
+	Plugins.Inputs = []io.Reader{input}
+	Plugins.Outputs = []io.Writer{test_output, http_output}
+
+	go Start(quit)
+
+	wg.Add(3)
+
+	curl := exec.Command("curl", "http://"+origin_address, "--header", "Transfer-Encoding: chunked", "--data-binary", "@README.md")
+	err := curl.Run()
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	wg.Wait()

--- a/output_http.go
+++ b/output_http.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strings"
 	"sync/atomic"
@@ -32,9 +31,6 @@ func (o *HTTPOutput) customCheckRedirect(req *http.Request, via []*http.Request)
 func ParseRequest(data []byte) (request *http.Request, err error) {
 	var body []byte
 
-	// Test if request have Transfer-Encoding: chunked
-	isChunked := bytes.Contains(data, []byte(": chunked\r\n"))
-
 	buf := bytes.NewBuffer(data)
 	reader := bufio.NewReader(buf)
 
@@ -46,12 +42,7 @@ func ParseRequest(data []byte) (request *http.Request, err error) {
 	}
 
 	if request.Method == "POST" {
-		// This works, because ReadRequest method modify buffer and strips all headers, leaving only body
-		if isChunked {
-			body, _ = ioutil.ReadAll(httputil.NewChunkedReader(reader))
-		} else {
-			body, _ = ioutil.ReadAll(reader)
-		}
+		body, _ = ioutil.ReadAll(reader)
 
 		bodyBuf := bytes.NewBuffer(body)
 

--- a/output_tcp_test.go
+++ b/output_tcp_test.go
@@ -44,6 +44,7 @@ func startTCP(cb func([]byte)) net.Listener {
 	go func() {
 		for {
 			conn, _ := listener.Accept()
+			defer conn.Close()
 
 			go func() {
 				reader := bufio.NewReader(conn)
@@ -59,7 +60,6 @@ func startTCP(cb func([]byte)) net.Listener {
 					}
 					cb(new_buf)
 				}
-				conn.Close()
 			}()
 		}
 	}()

--- a/raw_socket_listener/tcp_packet.go
+++ b/raw_socket_listener/tcp_packet.go
@@ -89,6 +89,7 @@ func (t *TCPPacket) String() string {
         "Window size:" + strconv.Itoa(int(t.Window)),
         "Checksum:" + strconv.Itoa(int(t.Checksum)),
 
+        "Data size:" + strconv.Itoa(len(t.Data)),
         "Data:" + string(t.Data),
     }, "\n")
 }


### PR DESCRIPTION
### Expect: 100-continue
Requests with [Expect: 100-continue](http://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html) use 2 tcp messages instead of 1: first waits for confirmation from server, second sends data. 

Since Gor use simple TCP parser and assumption that every request should be send using single message, it did not worked. 

I added special case, when it sees 100-continue request, it will wait for tcp message containing data, and will merge those messages (removing 100-continue request at all). 

### Chunked encoding handling moved to TCPMessage
Support for chunked encoding was added few days ago, but it worked inside HTTPOutput plugin. 
I moved to TCPMessage, so it normalize all HTTP requests, and any output (including file), will see simple POST request without chunk encoding. 

### Other notes

* I found that current TCP packet buffer is too small, and sometimes it cuts data, so i increased it.

Should fix #71 and #77