### PR TITLE
bug fixed check err connected HTTPClient.Send method

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -91,7 +91,9 @@ func (c *HTTPClient) isAlive() bool {
 func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 	if c.conn == nil || !c.isAlive() {
 		Debug("Connecting:", c.baseURL)
-		c.Connect()
+		if err = c.Connect(); err != nil {
+			return
+		}
 	}
 
 	timeout := time.Now().Add(5 * time.Second)


### PR DESCRIPTION
Bug fixed panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x50 pc=0x404360]

goroutine 20 [running]:
main.(*HTTPClient).Send(0xc20800ee70, 0xc2086402a0, 0xd6, 0xd6, 0x0, 0x0, 0x0, 0x0, 0x0)
        /path/to/github.com/buger/gor/http_client.go:99 +0x130
main.(*HTTPOutput).sendRequest(0xc20804c730, 0xc20800ee70, 0xc2086402a0, 0xd6, 0xd6)
        /path/to/github.com/buger/gor/output_http.go:146 +0x86
main.(*HTTPOutput).Worker(0xc20804c730)
        /path/to/github.com/buger/gor/output_http.go:100 +0x196
created by main.(*HTTPOutput).WorkerMaster
        /path/to/github.com/buger/gor/output_http.go:77 +0x7e

```