### PR TITLE
Improve http-client reliability and improve debug

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -39,6 +39,10 @@ func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
 				}
 			}
 
+			if Settings.debug {
+				Debug("[EMITTER] Sending paylod:", string(payload))
+			}
+
 			if Settings.splitOutput {
 				// Simple round robin
 				writers[wIndex].Write(payload)

--- a/http_client.go
+++ b/http_client.go
@@ -98,7 +98,7 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 
 			if _, ok := r.(error); !ok {
 				log.Println("[HTTPClient] Failed to send request: ", string(data))
-				fmt.Printf("PANIC: pkg: %v %s \n", r, debug.Stack())
+				log.Println("PANIC: pkg:", r, debug.Stack())
 			}
 		}
 	}()
@@ -107,7 +107,7 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 	if c.conn == nil || !c.isAlive() {
 		Debug("[HTTPClient] Connecting:", c.baseURL)
 		if err = c.Connect(); err != nil {
-			fmt.Printf("[HTTPClient] Connection error: %s\n", r)
+			log.Println("[HTTPClient] Connection error:", err)
 			return
 		}
 	}

--- a/settings.go
+++ b/settings.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	VERSION = "0.9.6"
+	VERSION = "0.9.7"
 )
 
 // Allows to specify multiple flags with same name and collects all values to array
@@ -25,6 +25,7 @@ func (h *MultiOption) Set(value string) error {
 
 type AppSettings struct {
 	verbose bool
+	debug bool
 	stats   bool
 
 	splitOutput bool
@@ -59,7 +60,8 @@ func usage() {
 func init() {
 	flag.Usage = usage
 
-	flag.BoolVar(&Settings.verbose, "verbose", false, "Turn on verbose/debug output")
+	flag.BoolVar(&Settings.verbose, "verbose", false, "Turn on more verbose output")
+	flag.BoolVar(&Settings.debug, "debug", false, "Turn on debug output, shows all itercepted traffic. Works only when with `verbose` flag")
 	flag.BoolVar(&Settings.stats, "stats", false, "Turn on queue stats output")
 
 	flag.BoolVar(&Settings.splitOutput, "split-output", false, "By default each output gets same traffic. If set to `true` it splits traffic equally among all outputs.")
@@ -113,7 +115,7 @@ func init() {
 
 func Debug(args ...interface{}) {
 	if Settings.verbose {
-		log.Print("[DEBUG] ")
+		fmt.Print("[DEBUG] ")
 		log.Println(args...)
 	}
 }


### PR DESCRIPTION
* Handle panic inside http client, it will show error message and failed http payload
* Handle connection error
* Improve debugging. Now there is additional flag `--debug` which will output all incoming http payloads