### PR TITLE
Avoid trailing null on hex encoded TCP

### DIFF
--- a/input_tcp.go
+++ b/input_tcp.go
@@ -67,7 +67,10 @@ func (i *TCPInput) handleConnection(conn net.Conn) {
 		encodedPayload := scanner.Bytes()
 		// Hex encoding always 2x number of bytes
 		decoded := make([]byte, len(encodedPayload)/2)
-		hex.Decode(decoded, encodedPayload)
+		_, err := hex.Decode(decoded, encodedPayload)
+		if err != nil {
+			log.Println("[TCPInput] failed to hex decode TCP payload:", err)
+		}
 		i.data <- decoded
 	}
 

--- a/output_tcp.go
+++ b/output_tcp.go
@@ -60,7 +60,8 @@ func (o *TCPOutput) Write(data []byte) (n int, err error) {
 	// Hex encoding always 2x number of bytes
 	encoded := make([]byte, len(data)*2+1)
 	hex.Encode(encoded, data)
-	o.buf <- append(encoded, '\n')
+	encoded[len(encoded)-1] = '\n'
+	o.buf <- encoded
 
 	if Settings.outputTCPStats {
 		o.bufStats.Write(len(o.buf))


### PR DESCRIPTION
Also fail loudly if hex decoding fails, as otherwise a request of just null bytes is handed to output.

Fixes #175.