### PR TITLE
Option to configure timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ gor --input-tcp replay.local:28020 --output-http http://staging.com --output-htt
 ```
 The given example will follow up to 2 redirects per request.
 
+### HTTP timeouts
+By default http timeout for both request and response is 5 seconds. You can override it like this:
+```
+gor --input-tcp replay.local:28020 --output-http http://staging.com --output-http-timeout 30s
+```
+
 ### Rate limiting
 Rate limiting can be useful if you want forward only part of production traffic and not overload your staging environment. There is 2 strategies: dropping random requests or dropping fraction of requests based on Header or URL param value. 
 

--- a/http_client.go
+++ b/http_client.go
@@ -21,6 +21,7 @@ type HTTPClientConfig struct {
 	FollowRedirects int
 	Debug           bool
 	OriginalHost    bool
+	Timeout  time.Duration
 }
 
 type HTTPClient struct {
@@ -41,6 +42,10 @@ func NewHTTPClient(baseURL string, config *HTTPClientConfig) *HTTPClient {
 	u, _ := url.Parse(baseURL)
 	if !strings.Contains(u.Host, ":") {
 		u.Host += ":" + defaultPorts[u.Scheme]
+	}
+
+	if config.Timeout.Nanoseconds() == 0 {
+		config.Timeout = 5 * time.Second
 	}
 
 	client := new(HTTPClient)
@@ -112,7 +117,7 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 		}
 	}
 
-	timeout := time.Now().Add(5 * time.Second)
+	timeout := time.Now().Add(c.config.Timeout)
 
 	c.conn.SetWriteDeadline(timeout)
 

--- a/output_http.go
+++ b/output_http.go
@@ -18,6 +18,7 @@ type HTTPOutputConfig struct {
 
 	elasticSearch string
 
+	Timeout time.Duration
 	OriginalHost bool
 
 	Debug bool
@@ -97,6 +98,7 @@ func (o *HTTPOutput) startWorker() {
 		FollowRedirects: o.config.redirectLimit,
 		Debug:           o.config.Debug,
 		OriginalHost:    o.config.OriginalHost,
+		Timeout: o.config.Timeout,
 	})
 
 	deathCount := 0

--- a/settings.go
+++ b/settings.go
@@ -87,6 +87,7 @@ func init() {
 	flag.Var(&Settings.outputHTTP, "output-http", "Forwards incoming requests to given http address.\n\t# Redirect all incoming requests to staging.com address \n\tgor --input-raw :80 --output-http http://staging.com")
 	flag.IntVar(&Settings.outputHTTPConfig.workers, "output-http-workers", 0, "Gor uses dynamic worker scaling by default.  Enter a number to run a set number of workers.")
 	flag.IntVar(&Settings.outputHTTPConfig.redirectLimit, "output-http-redirects", 0, "Enable how often redirects should be followed.")
+	flag.DurationVar(&Settings.outputHTTPConfig.Timeout, "output-http-timeout", 0, "Specify HTTP request/response timeout. By default 5s. Example: --output-http-timeout 30s")
 
 	flag.BoolVar(&Settings.outputHTTPConfig.stats, "output-http-stats", false, "Report http output queue stats to console every 5 seconds.")
 


### PR DESCRIPTION
Now you can configure http-output format with `--output-http-timeout 30s`. By default it is 5s. 