### PR TITLE
Fix large responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: go
 go: 1.4.2
-script: sudo -E bash -c "source /etc/profile && eval '$(gimme 1.4.2)' && export GOPATH=$HOME/gopath:$GOPATH && go get && GORACE='halt_on_error=1' go test ./... -v -timeout 15s --verbose"
+script: sudo -E bash -c "source /etc/profile && eval '$(gimme 1.4.2)' && export GOPATH=$HOME/gopath:$GOPATH && go get && GORACE='halt_on_error=1' go test ./... -v -timeout 15s"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: go
 go: 1.4.2
-script: sudo -E bash -c "source /etc/profile && eval '$(gimme 1.4.2)' && export GOPATH=$HOME/gopath:$GOPATH && go get && GORACE='halt_on_error=1' go test ./... -v -timeout 15s"
+script: sudo -E bash -c "source /etc/profile && eval '$(gimme 1.4.2)' && export GOPATH=$HOME/gopath:$GOPATH && go get && GORACE='halt_on_error=1' go test ./... -v -timeout 15s --verbose"

--- a/http_client.go
+++ b/http_client.go
@@ -22,6 +22,7 @@ type HTTPClientConfig struct {
 	Debug           bool
 	OriginalHost    bool
 	Timeout         time.Duration
+	ResponseBufferSize  int
 }
 
 type HTTPClient struct {
@@ -48,11 +49,15 @@ func NewHTTPClient(baseURL string, config *HTTPClientConfig) *HTTPClient {
 		config.Timeout = 5 * time.Second
 	}
 
+	if config.ResponseBufferSize == 0 {
+		config.ResponseBufferSize = 512*1024 // 500kb
+	}
+
 	client := new(HTTPClient)
 	client.baseURL = u.String()
 	client.host = u.Host
 	client.scheme = u.Scheme
-	client.respBuf = make([]byte, 512*1024) // 500kb
+	client.respBuf = make([]byte, config.ResponseBufferSize)
 	client.config = config
 
 	return client

--- a/http_client.go
+++ b/http_client.go
@@ -21,7 +21,7 @@ type HTTPClientConfig struct {
 	FollowRedirects int
 	Debug           bool
 	OriginalHost    bool
-	Timeout  time.Duration
+	Timeout         time.Duration
 }
 
 type HTTPClient struct {
@@ -137,7 +137,7 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 	c.conn.SetReadDeadline(timeout)
 	n, err := c.conn.Read(c.respBuf)
 
-	// If response large then our buffer, we need to read all reponse buffer
+	// If response large then our buffer, we need to read all response buffer
 	// Otherwise it will corrupt response of next request
 	// Parsing response body is non trivial thing, especially with keep-alive
 	// Simples case is to to close connection if response too large

--- a/http_client.go
+++ b/http_client.go
@@ -154,6 +154,8 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 
 	payload := c.respBuf[:n]
 
+	Debug("[HTTPClient] Received:", n)
+
 	if c.config.Debug {
 		Debug("[HTTPClient] Received:", string(payload))
 	}

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -91,7 +91,7 @@ func TestHTTPClientResponseBuffer(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-		size := 1 * 1024 * 1024 // 1 MB
+		size := 10 * 1024 // 10kb
 		rb := make([]byte, size)
 		rand.Read(rb)
 
@@ -100,7 +100,7 @@ func TestHTTPClientResponseBuffer(t *testing.T) {
 		wg.Done()
 	}))
 
-	client := NewHTTPClient(server.URL, &HTTPClientConfig{Debug: false})
+	client := NewHTTPClient(server.URL, &HTTPClientConfig{Debug: false, ResponseBufferSize: 1024})
 
 	wg.Add(2)
 	client.Send(payload)

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"crypto/rand"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -8,8 +10,6 @@ import (
 	"net/http/httputil"
 	"sync"
 	"testing"
-	"crypto/rand"
-	"bytes"
 	_ "time"
 )
 
@@ -100,7 +100,7 @@ func TestHTTPClientResponseBuffer(t *testing.T) {
 		wg.Done()
 	}))
 
-	client := NewHTTPClient(server.URL, &HTTPClientConfig{Debug: true})
+	client := NewHTTPClient(server.URL, &HTTPClientConfig{Debug: false})
 
 	wg.Add(2)
 	client.Send(payload)

--- a/output_http.go
+++ b/output_http.go
@@ -18,7 +18,7 @@ type HTTPOutputConfig struct {
 
 	elasticSearch string
 
-	Timeout time.Duration
+	Timeout      time.Duration
 	OriginalHost bool
 
 	Debug bool
@@ -98,7 +98,7 @@ func (o *HTTPOutput) startWorker() {
 		FollowRedirects: o.config.redirectLimit,
 		Debug:           o.config.Debug,
 		OriginalHost:    o.config.OriginalHost,
-		Timeout: o.config.Timeout,
+		Timeout:         o.config.Timeout,
 	})
 
 	deathCount := 0


### PR DESCRIPTION
If response large then our buffer, we need to read all response buffer, otherwise it will corrupt response of next request.

Detecting end of response body is non trivial thing, especially with keep-alive.
Simples case is to to close connection if response too large.

Should fix https://github.com/buger/gor/issues/184