### PR TITLE
move request file format specification/handling into own package

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/buger/gor/requestfiles"
 	"io"
 	"math/rand"
 	"strconv"
@@ -40,8 +41,8 @@ func NewLimiter(plugin interface{}, options string) io.ReadWriter {
 	l.currentTime = time.Now().UnixNano()
 
 	// FileInput have its own rate limiting. Unlike other inputs we not just dropping requests, we can slow down or speed up request emittion.
-	if fi, ok := l.plugin.(*FileInput); ok && l.isPercent {
-		fi.speedFactor = float64(l.limit) / float64(100)
+	if fi, ok := l.plugin.(*requestfiles.FileInput); ok && l.isPercent {
+		fi.SpeedFactor = float64(l.limit) / float64(100)
 	}
 
 	return l
@@ -49,7 +50,7 @@ func NewLimiter(plugin interface{}, options string) io.ReadWriter {
 
 func (l *Limiter) isLimited() bool {
 	// File input have its own limiting algorithm
-	if _, ok := l.plugin.(*FileInput); ok && l.isPercent {
+	if _, ok := l.plugin.(*requestfiles.FileInput); ok && l.isPercent {
 		return false
 	}
 

--- a/output_file_test.go
+++ b/output_file_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/buger/gor/requestfiles"
 	"io"
 	"sync"
 	"testing"
@@ -11,7 +12,7 @@ func TestFileOutput(t *testing.T) {
 	quit := make(chan int)
 
 	input := NewTestInput()
-	output := NewFileOutput("/tmp/test_requests.gor")
+	output := requestfiles.NewFileOutput("/tmp/test_requests.gor")
 
 	Plugins.Inputs = []io.Reader{input}
 	Plugins.Outputs = []io.Writer{output}
@@ -27,7 +28,7 @@ func TestFileOutput(t *testing.T) {
 
 	quit = make(chan int)
 
-	input2 := NewFileInput("/tmp/test_requests.gor")
+	input2 := requestfiles.NewFileInput("/tmp/test_requests.gor")
 	output2 := NewTestOutput(func(data []byte) {
 		wg.Done()
 	})

--- a/plugins.go
+++ b/plugins.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/buger/gor/requestfiles"
 	"io"
 	"reflect"
 	"strings"
@@ -87,11 +88,11 @@ func InitPlugins() {
 	}
 
 	for _, options := range Settings.inputFile {
-		registerPlugin(NewFileInput, options)
+		registerPlugin(requestfiles.NewFileInput, options)
 	}
 
 	for _, options := range Settings.outputFile {
-		registerPlugin(NewFileOutput, options)
+		registerPlugin(requestfiles.NewFileOutput, options)
 	}
 
 	for _, options := range Settings.inputHTTP {

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/buger/gor/requestfiles"
 	"io"
 	"testing"
 )
@@ -24,7 +25,7 @@ func TestPluginsRegistration(t *testing.T) {
 		t.Errorf("First input should be DummyInput")
 	}
 
-	if _, ok := Plugins.Inputs[1].(*FileInput); !ok {
+	if _, ok := Plugins.Inputs[1].(*requestfiles.FileInput); !ok {
 		t.Errorf("Second input should be FileInput")
 	}
 

--- a/requestfiles/input_file.go
+++ b/requestfiles/input_file.go
@@ -1,4 +1,4 @@
-package main
+package requestfiles
 
 import (
 	"encoding/gob"
@@ -12,7 +12,7 @@ type FileInput struct {
 	data        chan []byte
 	path        string
 	decoder     *gob.Decoder
-	speedFactor float64
+	SpeedFactor float64
 }
 
 // NewFileInput constructor for FileInput. Accepts file path as argument.
@@ -20,7 +20,7 @@ func NewFileInput(path string) (i *FileInput) {
 	i = new(FileInput)
 	i.data = make(chan []byte)
 	i.path = path
-	i.speedFactor = 1
+	i.SpeedFactor = 1
 	i.init(path)
 
 	go i.emit()
@@ -64,8 +64,8 @@ func (i *FileInput) emit() {
 			timeDiff := raw.Timestamp - lastTime
 
 			// We can speedup or slowdown execution based on speedFactor
-			if i.speedFactor != 1 {
-				timeDiff = int64(float64(raw.Timestamp-lastTime) / i.speedFactor)
+			if i.SpeedFactor != 1 {
+				timeDiff = int64(float64(raw.Timestamp-lastTime) / i.SpeedFactor)
 			}
 
 			time.Sleep(time.Duration(timeDiff))

--- a/requestfiles/output_file.go
+++ b/requestfiles/output_file.go
@@ -1,4 +1,4 @@
-package main
+package requestfiles
 
 import (
 	"encoding/gob"


### PR DESCRIPTION
I wanted to be able to write gor-compatible files in another program, so I moved the reader/writer code out of the gor `main` package, so it can be imported elsewhere.

I'm also fine re-implementing the format in my own project (since it is so simple) if it seems like this refactor introduces complexity or mess in gor, but my thinking was if/when gor decided to do anything fancier with its file format, it seemed like this approach minimized code duplication for other tools that work with its files.