### PR TITLE
Improve raw input scheduler

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -53,7 +53,7 @@ func NewHTTPClient(baseURL string, config *HTTPClientConfig) *HTTPClient {
 	}
 
 	if config.ResponseBufferSize == 0 {
-		config.ResponseBufferSize = 512 * 1024 // 500kb
+		config.ResponseBufferSize = 100 * 1024 // 100kb
 	}
 
 	client := new(HTTPClient)

--- a/input_raw.go
+++ b/input_raw.go
@@ -37,9 +37,9 @@ func (i *RAWInput) Read(data []byte) (int, error) {
 	var header []byte
 
 	if msg.IsIncoming {
-		header = payloadHeader(RequestPayload, msg.UUID(), msg.Start)
+		header = payloadHeader(RequestPayload, msg.UUID(), msg.Start.UnixNano())
 	} else {
-		header = payloadHeader(ResponsePayload, msg.UUID(), msg.End-msg.RequestStart)
+		header = payloadHeader(ResponsePayload, msg.UUID(), msg.End.UnixNano()-msg.RequestStart.UnixNano())
 	}
 
 	copy(data[0:len(header)], header)

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -214,6 +214,10 @@ var httpMethods []string = []string{
 }
 
 func IsHTTPPayload(payload []byte) bool {
+	if len(payload) < 4 {
+		return false
+	}
+
 	method := string(payload[0:4])
 
 	for _, m := range httpMethods {


### PR DESCRIPTION
Get rid of timers, and implement simple tcp messages scheduler, which decide if message should be dispatched or ignored. This should fix memory leaks and potentially improve some speed. 

Binaries:
https://www.dropbox.com/s/4kqy0f66rh6vwdn/gor_new_tcp_scheduler_x86.tar.gz?dl=1
https://www.dropbox.com/s/898z5oascypct61/gor_new_tcp_scheduler_x64.tar.gz?dl=1