### PR TITLE
Fix file input replay speed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ drun:
 	docker run -v `pwd`:$(SOURCE_PATH) -t -i gor go run $(SOURCE) --input-dummy=0 --output-http="http://localhost:9000" --input-raw :9000 --input-http :9000 --verbose --debug --middleware "./examples/middleware/echo.sh"
 
 drun-2:
-	docker run -v `pwd`:$(SOURCE_PATH) -t -i gor go run $(SOURCE) --input-http :9001 --output-dummy=0
+	docker run -v `pwd`:$(SOURCE_PATH) -t -i gor go run $(SOURCE) --input-file ./fixtures/requests.gor --output-dummy=0
 
 drecord:
 	docker run -v `pwd`:$(SOURCE_PATH) -t -i gor go run $(SOURCE) --input-dummy=0 --output-file=requests.gor --verbose --debug

--- a/input_file.go
+++ b/input_file.go
@@ -61,15 +61,18 @@ func (i *FileInput) emit() {
 		buf := scanner.Bytes()
 		meta := payloadMeta(buf)
 
-		if meta[0][0] == RequestPayload && lastTime != 0 {
+		if meta[0][0] == RequestPayload {
 			ts, _ := strconv.ParseInt(string(meta[2]), 10, 64)
-			timeDiff := ts - lastTime
 
-			if i.speedFactor != 1 {
-				timeDiff = int64(float64(timeDiff) / i.speedFactor)
+			if lastTime != 0 {
+				timeDiff := ts - lastTime
+
+				if i.speedFactor != 1 {
+					timeDiff = int64(float64(timeDiff) / i.speedFactor)
+				}
+
+				time.Sleep(time.Duration(timeDiff))
 			}
-
-			time.Sleep(time.Duration(timeDiff))
 
 			lastTime = ts
 		}


### PR DESCRIPTION
Currently it replays all the requests at once, without preserving original speed

Binaries:
https://www.dropbox.com/s/53k4rrsk61vgc9l/gor_file_input_speed_fix_x64.tar.gz?dl=1
https://www.dropbox.com/s/9zjxecqoe2cgu0j/gor_file_input_speed_fix_x86.tar.gz?dl=1