### PR TITLE
Middleware refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 *.class
 
 *.test
+.idea
 
 gor

--- a/emitter.go
+++ b/emitter.go
@@ -67,16 +67,11 @@ func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
 		nr, er := src.Read(buf)
 
 		if nr > 0 && len(buf) > nr {
-			payload := make([]byte, nr)
-			copy(payload, buf[:nr])
+			payload := buf[:nr]
 
-			_maxN := nr
-			if nr > 500 {
-				_maxN = 500
-			}
 
 			if Settings.debug {
-				Debug("[EMITTER] input:", string(payload[0:_maxN]), nr, "from:", src)
+				Debug("[EMITTER] input:", stringLimit(payload), nr, "from:", src)
 			}
 
 			if modifier != nil && isRequestPayload(payload) {
@@ -94,13 +89,8 @@ func CopyMulty(src io.Reader, writers ...io.Writer) (err error) {
 					payload = append(payload[:headSize], body...)
 				}
 
-				_maxN = len(payload)
-				if len(payload) > 500 {
-					_maxN = 500
-				}
-
 				if Settings.debug {
-					Debug("[EMITTER] Rewrittern input:", len(payload), "First 500 bytes:", string(payload[0:_maxN]))
+					Debug("[EMITTER] Rewrittern input:", len(payload), "First 500 bytes:", stringLimit(payload))
 				}
 			}
 

--- a/emitter.go
+++ b/emitter.go
@@ -27,27 +27,21 @@ func Start(stop chan int) {
 		}
 	}
 
-	middlewares := make([]io.ReadWriter, 0)
-
-	for _, cmd := range Settings.middleware {
-		middlewares = append(middlewares, NewExternalMiddleware(cmd))
-	}
-
-	if len(middlewares) > 0 {
+	if len(Middleware) > 0 {
 		// All readers report to first middleware in pipeline
 		for _, reader := range readers {
-			go CopyMulty(reader, middlewares[0])
+			go CopyMulty(reader, Middleware[0])
 		}
 
 		// Middleware pipeline
-		for i, mw := range middlewares {
-			if i < len(middlewares)-1 {
-				go CopyMulty(mw, middlewares[i+1])
+		for i, mw := range Middleware {
+			if i < len(Middleware)-1 {
+				go CopyMulty(mw, Middleware[i+1])
 			}
 		}
 
 		// Last middleware in pipeline report to writers
-		go CopyMulty(middlewares[len(middlewares)-1], writers...)
+		go CopyMulty(Middleware[len(Middleware)-1], writers...)
 	} else {
 		for _, in := range readers {
 			go CopyMulty(in, writers...)

--- a/emitter.go
+++ b/emitter.go
@@ -27,8 +27,8 @@ func Start(stop chan int) {
 		}
 	}
 
-	if Settings.middleware != "" {
-		middleware := NewMiddleware(Settings.middleware)
+	if len(Settings.middleware) > 0 {
+		middleware := NewMiddleware(Settings.middleware[0])
 
 		for _, reader := range readers {
 			go CopyMulty(reader, middleware)

--- a/emitter_test.go
+++ b/emitter_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,8 +15,7 @@ func TestEmitter(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -49,8 +47,7 @@ func TestEmitterRoundRobin(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output1, output2}
+	testPlugins(input, output1, output2)
 
 	Settings.splitOutput = true
 
@@ -82,8 +79,7 @@ func BenchmarkEmitter(b *testing.B) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 

--- a/gor.go
+++ b/gor.go
@@ -37,7 +37,7 @@ func main() {
 	flag.Parse()
 	InitPlugins()
 
-	if len(Plugins.Inputs) == 0 || len(Plugins.Outputs) == 0 {
+	if len(Plugins) < 2 {
 		log.Fatal("Required at least 1 input and 1 output")
 	}
 

--- a/http_modifier.go
+++ b/http_modifier.go
@@ -3,39 +3,46 @@ package main
 import (
 	"bytes"
 	"hash/fnv"
+	"log"
 
 	"github.com/buger/gor/proto"
 )
 
 type HTTPModifier struct {
+	output chan []byte
 	config *HTTPModifierConfig
 }
 
 func NewHTTPModifier(config *HTTPModifierConfig) *HTTPModifier {
-	// Optimization to skip modifier completely if we do not need it
-	if len(config.urlRegexp) == 0 &&
-		len(config.urlNegativeRegexp) == 0 &&
-		len(config.urlRewrite) == 0 &&
-		len(config.headerFilters) == 0 &&
-		len(config.headerNegativeFilters) == 0 &&
-		len(config.headerHashFilters) == 0 &&
-		len(config.paramHashFilters) == 0 &&
-		len(config.params) == 0 &&
-		len(config.headers) == 0 &&
-		len(config.methods) == 0 {
-		return nil
-	}
+	m := &HTTPModifier{config: config}
 
-	return &HTTPModifier{config: config}
+	m.output = make(chan []byte, 1000)
+
+	return m
 }
 
-func (m *HTTPModifier) Rewrite(payload []byte) (response []byte) {
-	if !proto.IsHTTPPayload(payload) {
-		return payload
+func (m *HTTPModifier) Read(data []byte) (int, error) {
+	buf := <-m.output
+	copy(data, buf)
+
+	return len(buf), nil
+}
+
+func (m *HTTPModifier) Write(payload []byte) (int, error) {
+	if !isRequestPayload(payload) {
+		m.output <- payload
+		return len(payload), nil
+	}
+
+	body := payloadBody(payload)
+
+	if !proto.IsHTTPPayload(body) {
+		m.output <- payload
+		return len(payload), nil
 	}
 
 	if len(m.config.methods) > 0 {
-		method := proto.Method(payload)
+		method := proto.Method(body)
 
 		matched := false
 
@@ -47,24 +54,12 @@ func (m *HTTPModifier) Rewrite(payload []byte) (response []byte) {
 		}
 
 		if !matched {
-			return
-		}
-	}
-
-	if len(m.config.headers) > 0 {
-		for _, header := range m.config.headers {
-			payload = proto.SetHeader(payload, []byte(header.Name), []byte(header.Value))
-		}
-	}
-
-	if len(m.config.params) > 0 {
-		for _, param := range m.config.params {
-			payload = proto.SetPathParam(payload, param.Name, param.Value)
+			return 0, nil
 		}
 	}
 
 	if len(m.config.urlRegexp) > 0 {
-		path := proto.Path(payload)
+		path := proto.Path(body)
 
 		matched := false
 
@@ -76,50 +71,50 @@ func (m *HTTPModifier) Rewrite(payload []byte) (response []byte) {
 		}
 
 		if !matched {
-			return
+			return 0, nil
 		}
 	}
 
 	if len(m.config.urlNegativeRegexp) > 0 {
-		path := proto.Path(payload)
+		path := proto.Path(body)
 
 		for _, f := range m.config.urlNegativeRegexp {
 			if f.regexp.Match(path) {
-				return
+				return 0, nil
 			}
 		}
 	}
 
 	if len(m.config.headerFilters) > 0 {
 		for _, f := range m.config.headerFilters {
-			value := proto.Header(payload, f.name)
+			value := proto.Header(body, f.name)
 
 			if len(value) > 0 && !f.regexp.Match(value) {
-				return
+				return 0, nil
 			}
 		}
 	}
 
 	if len(m.config.headerNegativeFilters) > 0 {
 		for _, f := range m.config.headerNegativeFilters {
-			value := proto.Header(payload, f.name)
+			value := proto.Header(body, f.name)
 
 			if len(value) > 0 && f.regexp.Match(value) {
-				return
+				return 0, nil
 			}
 		}
 	}
 
 	if len(m.config.headerHashFilters) > 0 {
 		for _, f := range m.config.headerHashFilters {
-			value := proto.Header(payload, f.name)
+			value := proto.Header(body, f.name)
 
 			if len(value) > 0 {
 				hasher := fnv.New32a()
 				hasher.Write(value)
 
 				if (hasher.Sum32() % 100) >= f.percent {
-					return
+					return 0, nil
 				}
 			}
 		}
@@ -127,31 +122,67 @@ func (m *HTTPModifier) Rewrite(payload []byte) (response []byte) {
 
 	if len(m.config.paramHashFilters) > 0 {
 		for _, f := range m.config.paramHashFilters {
-			value, s, _ := proto.PathParam(payload, f.name)
+			value, s, _ := proto.PathParam(body, f.name)
 
 			if s != -1 {
 				hasher := fnv.New32a()
 				hasher.Write(value)
 
 				if (hasher.Sum32() % 100) >= f.percent {
-					return
+					return 0, nil
 				}
 			}
 		}
 	}
 
+	isChanged := false
+
+	if len(m.config.headers) > 0 {
+		for _, header := range m.config.headers {
+			isChanged = true
+			body = proto.SetHeader(body, []byte(header.Name), []byte(header.Value))
+		}
+	}
+
+	if len(m.config.params) > 0 {
+		for _, param := range m.config.params {
+			isChanged = true
+			body = proto.SetPathParam(body, param.Name, param.Value)
+		}
+	}
+
 	if len(m.config.urlRewrite) > 0 {
-		path := proto.Path(payload)
+		path := proto.Path(body)
 
 		for _, f := range m.config.urlRewrite {
 			if f.src.Match(path) {
+
+				log.Println(string(path))
+				isChanged = true
+
 				path = f.src.ReplaceAll(path, f.target)
-				payload = proto.SetPath(payload, path)
+				body = proto.SetPath(body, path)
 
 				break
 			}
 		}
 	}
 
-	return payload
+	if isChanged {
+		headerSize := bytes.IndexByte(payload, '\n')
+		payload = append(payload[:headerSize+1], body...)
+	}
+
+	m.output <- payload
+	return len(payload), nil
+}
+
+func (m *HTTPModifier) Rewrite(payload []byte) []byte {
+	n, _ := m.Write(payload)
+
+	if n == 0 {
+		return []byte{}
+	}
+
+	return <-m.output
 }

--- a/http_modifier_settings.go
+++ b/http_modifier_settings.go
@@ -23,6 +23,23 @@ type HTTPModifierConfig struct {
 	methods HTTPMethods
 }
 
+func (config *HTTPModifierConfig) IsEmpty() bool {
+	if len(config.urlRegexp) == 0 &&
+		len(config.urlNegativeRegexp) == 0 &&
+		len(config.urlRewrite) == 0 &&
+		len(config.headerFilters) == 0 &&
+		len(config.headerNegativeFilters) == 0 &&
+		len(config.headerHashFilters) == 0 &&
+		len(config.paramHashFilters) == 0 &&
+		len(config.params) == 0 &&
+		len(config.headers) == 0 &&
+		len(config.methods) == 0 {
+		return true
+	}
+
+	return false
+}
+
 //
 // Handling of --http-allow-header, --http-disallow-header options
 //

--- a/input_http_test.go
+++ b/input_http_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/buger/gor/proto"
-	"io"
 	"log"
 	"net/http"
 	"os/exec"
@@ -20,8 +19,7 @@ func TestHTTPInput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -55,8 +53,8 @@ func TestInputHTTPLargePayload(t *testing.T) {
 		}
 		wg.Done()
 	})
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+
+	testPlugins(input, output)
 
 	go Start(quit)
 

--- a/input_raw_test.go
+++ b/input_raw_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -45,8 +44,7 @@ func TestRAWInput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	client := NewHTTPClient(origin.URL, &HTTPClientConfig{})
 
@@ -112,8 +110,7 @@ func TestInputRAW100Expect(t *testing.T) {
 
 	httpOutput := NewHTTPOutput(replay.URL, &HTTPOutputConfig{})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{testOutput, httpOutput}
+	testPlugins(input, testOutput, httpOutput)
 
 	go Start(quit)
 
@@ -162,8 +159,7 @@ func TestInputRAWChunkedEncoding(t *testing.T) {
 
 	httpOutput := NewHTTPOutput(replay.URL, &HTTPOutputConfig{Debug: true})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{httpOutput}
+	testPlugins(input, httpOutput)
 
 	go Start(quit)
 
@@ -222,8 +218,7 @@ func TestInputRAWLargePayload(t *testing.T) {
 
 	httpOutput := NewHTTPOutput(replay.URL, &HTTPOutputConfig{Debug: false})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{httpOutput}
+	testPlugins(input, httpOutput)
 
 	go Start(quit)
 

--- a/input_tcp_test.go
+++ b/input_tcp_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"log"
 	"net"
 	"sync"
@@ -17,8 +16,7 @@ func TestTCPInput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -56,8 +54,7 @@ func BenchmarkTCPInput(b *testing.B) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"io"
 	"sync"
 	"testing"
 )
@@ -18,8 +17,7 @@ func TestOutputLimiter(t *testing.T) {
 	}), "10")
 	wg.Add(10)
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -42,8 +40,7 @@ func TestInputLimiter(t *testing.T) {
 	})
 	wg.Add(10)
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -66,8 +63,7 @@ func TestPercentLimiter1(t *testing.T) {
 		wg.Done()
 	}), "0%")
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -91,8 +87,7 @@ func TestPercentLimiter2(t *testing.T) {
 	}), "100%")
 	wg.Add(100)
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 

--- a/middleware.go
+++ b/middleware.go
@@ -15,7 +15,6 @@ import (
 type ExternalMiddleware struct {
 	command string
 
-	input  chan []byte
 	output chan []byte
 
 	mu sync.Mutex
@@ -28,7 +27,6 @@ func NewExternalMiddleware(command string) *ExternalMiddleware {
 	m := new(ExternalMiddleware)
 	m.command = command
 
-	m.input = make(chan []byte, 1000)
 	m.output = make(chan []byte, 1000)
 
 	commands := strings.Split(command, " ")
@@ -88,7 +86,7 @@ func (m *ExternalMiddleware) Read(data []byte) (int, error) {
 }
 
 func (m *ExternalMiddleware) Write(data []byte) (int, error) {
-	dst := make([]byte, len(data) * 2 + 1)
+	dst := make([]byte, len(data)*2+1)
 
 	hex.Encode(dst, data)
 	dst[len(dst)-1] = '\n'

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -112,7 +112,7 @@ func TestEchoMiddleware(t *testing.T) {
 
 	quit := make(chan int)
 
-	Settings.middleware = MultiOption{"./examples/middleware/echo.sh"}
+	Settings.middleware = MultiOption{"./examples/middleware/echo.sh", "./examples/middleware/echo.sh"}
 
 	// Catch traffic from one service
 	input := NewRAWInput(from.Listener.Addr().String(), testRawExpire)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"github.com/buger/gor/proto"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -122,8 +121,7 @@ func TestEchoMiddleware(t *testing.T) {
 	// And redirect to another
 	output := NewHTTPOutput(to.URL, &HTTPOutputConfig{Debug: false})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	// Start Gor
 	go Start(quit)
@@ -181,8 +179,7 @@ func TestTokenMiddleware(t *testing.T) {
 	// And redirect to another
 	output := NewHTTPOutput(to.URL, &HTTPOutputConfig{Debug: true})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	// Start Gor
 	go Start(quit)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -112,7 +112,7 @@ func TestEchoMiddleware(t *testing.T) {
 
 	quit := make(chan int)
 
-	Settings.middleware = "./examples/middleware/echo.sh"
+	Settings.middleware = MultiOption{"./examples/middleware/echo.sh"}
 
 	// Catch traffic from one service
 	input := NewRAWInput(from.Listener.Addr().String(), testRawExpire)
@@ -142,7 +142,7 @@ func TestEchoMiddleware(t *testing.T) {
 	close(quit)
 	time.Sleep(200 * time.Millisecond)
 
-	Settings.middleware = ""
+	Settings.middleware = MultiOption{}
 }
 
 func TestTokenMiddleware(t *testing.T) {
@@ -169,7 +169,7 @@ func TestTokenMiddleware(t *testing.T) {
 
 	quit := make(chan int)
 
-	Settings.middleware = "go run ./examples/middleware/token_modifier.go"
+	Settings.middleware = MultiOption{"go run ./examples/middleware/token_modifier.go"}
 
 	fromAddr := strings.Replace(from.Listener.Addr().String(), "[::]", "127.0.0.1", -1)
 	// Catch traffic from one service
@@ -209,5 +209,5 @@ func TestTokenMiddleware(t *testing.T) {
 	wg.Wait()
 	close(quit)
 	time.Sleep(100 * time.Millisecond)
-	Settings.middleware = ""
+	Settings.middleware = MultiOption{}
 }

--- a/output_file_test.go
+++ b/output_file_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"sync"
 	"testing"
 )
@@ -13,8 +12,7 @@ func TestFileOutput(t *testing.T) {
 	input := NewTestInput()
 	output := NewFileOutput("/tmp/test_requests.gor")
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -32,8 +30,7 @@ func TestFileOutput(t *testing.T) {
 		wg.Done()
 	})
 
-	Plugins.Inputs = []io.Reader{input2}
-	Plugins.Outputs = []io.Writer{output2}
+	testPlugins(input2, output2)
 
 	go Start(quit)
 

--- a/output_http.go
+++ b/output_http.go
@@ -85,7 +85,7 @@ func NewHTTPOutput(address string, config *HTTPOutputConfig) io.Writer {
 		o.elasticSearch.Init(o.config.elasticSearch)
 	}
 
-	if len(Settings.middleware) > 0 {
+	if len(Middleware) > 0 {
 		o.config.TrackResponses = true
 	}
 

--- a/output_http.go
+++ b/output_http.go
@@ -3,9 +3,9 @@ package main
 import (
 	"github.com/buger/gor/proto"
 	"io"
+	_ "log"
 	"sync/atomic"
 	"time"
-	_ "log"
 )
 
 const initialDynamicWorkers = 10

--- a/output_http.go
+++ b/output_http.go
@@ -151,7 +151,10 @@ func (o *HTTPOutput) Write(data []byte) (n int, err error) {
 		return len(data), nil
 	}
 
-	o.queue <- data
+	buf := make([]byte, len(data))
+	copy(buf, data)
+
+	o.queue <- buf
 
 	if o.config.stats {
 		o.queueStats.Write(len(o.queue))

--- a/output_http.go
+++ b/output_http.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sync/atomic"
 	"time"
+	_ "log"
 )
 
 const initialDynamicWorkers = 10
@@ -150,10 +151,7 @@ func (o *HTTPOutput) Write(data []byte) (n int, err error) {
 		return len(data), nil
 	}
 
-	buf := make([]byte, len(data))
-	copy(buf, data)
-
-	o.queue <- buf
+	o.queue <- data
 
 	if o.config.stats {
 		o.queueStats.Write(len(o.queue))

--- a/output_http_test.go
+++ b/output_http_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -45,8 +44,7 @@ func TestHTTPOutput(t *testing.T) {
 
 	output := NewHTTPOutput(server.URL, &HTTPOutputConfig{Debug: true})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -84,8 +82,7 @@ func TestHTTPOutputKeepOriginalHost(t *testing.T) {
 
 	output := NewHTTPOutput(server.URL, &HTTPOutputConfig{Debug: false, OriginalHost: true})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -111,8 +108,7 @@ func TestOutputHTTPSSL(t *testing.T) {
 	input := NewTestInput()
 	output := NewHTTPOutput(server.URL, &HTTPOutputConfig{})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -138,8 +134,7 @@ func BenchmarkHTTPOutput(b *testing.B) {
 	input := NewTestInput()
 	output := NewHTTPOutput(server.URL, &HTTPOutputConfig{})
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 

--- a/output_http_test.go
+++ b/output_http_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +41,7 @@ func TestHTTPOutput(t *testing.T) {
 
 	headers := HTTPHeaders{HTTPHeader{"User-Agent", "Gor"}}
 	methods := HTTPMethods{[]byte("GET"), []byte("PUT"), []byte("POST")}
-	Settings.modifierConfig = HTTPModifierConfig{headers: headers, methods: methods}
+	Middleware = []io.ReadWriter{NewHTTPModifier(&HTTPModifierConfig{headers: headers, methods: methods})}
 
 	output := NewHTTPOutput(server.URL, &HTTPOutputConfig{Debug: true})
 
@@ -59,7 +60,7 @@ func TestHTTPOutput(t *testing.T) {
 
 	close(quit)
 
-	Settings.modifierConfig = HTTPModifierConfig{}
+	Middleware = []io.ReadWriter{}
 }
 
 func TestHTTPOutputKeepOriginalHost(t *testing.T) {
@@ -78,7 +79,7 @@ func TestHTTPOutputKeepOriginalHost(t *testing.T) {
 	defer server.Close()
 
 	headers := HTTPHeaders{HTTPHeader{"Host", "custom-host.com"}}
-	Settings.modifierConfig = HTTPModifierConfig{headers: headers}
+	Middleware = []io.ReadWriter{NewHTTPModifier(&HTTPModifierConfig{headers: headers})}
 
 	output := NewHTTPOutput(server.URL, &HTTPOutputConfig{Debug: false, OriginalHost: true})
 
@@ -93,7 +94,7 @@ func TestHTTPOutputKeepOriginalHost(t *testing.T) {
 
 	close(quit)
 
-	Settings.modifierConfig = HTTPModifierConfig{}
+	Middleware = []io.ReadWriter{}
 }
 
 func TestOutputHTTPSSL(t *testing.T) {

--- a/output_tcp_test.go
+++ b/output_tcp_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"io"
 	"log"
 	"net"
 	"sync"
@@ -19,8 +18,7 @@ func TestTCPOutput(t *testing.T) {
 	input := NewTestInput()
 	output := NewTCPOutput(listener.Addr().String())
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 
@@ -71,8 +69,7 @@ func BenchmarkTCPOutput(b *testing.B) {
 	input := NewTestInput()
 	output := NewTCPOutput(listener.Addr().String())
 
-	Plugins.Inputs = []io.Reader{input}
-	Plugins.Outputs = []io.Writer{output}
+	testPlugins(input, output)
 
 	go Start(quit)
 

--- a/plugins.go
+++ b/plugins.go
@@ -1,20 +1,16 @@
 package main
 
 import (
-	"io"
 	"reflect"
 	"strings"
 	"time"
+	"io"
 )
 
-// InOutPlugins struct for holding references to plugins
-type InOutPlugins struct {
-	Inputs  []io.Reader
-	Outputs []io.Writer
-}
+type plugins []interface{}
 
 // Plugins holds all the plugin objects
-var Plugins *InOutPlugins = new(InOutPlugins)
+var Plugins plugins
 
 // extractLimitOptions detects if plugin get called with limiter support
 // Returns address and limit
@@ -56,17 +52,7 @@ func registerPlugin(constructor interface{}, options ...interface{}) {
 		pluginWrapper = plugin
 	}
 
-	_, isR := plugin.(io.Reader)
-	_, isW := plugin.(io.Writer)
-
-	// Some of the output can be Readers as well because return responses
-	if isR && !isW {
-		Plugins.Inputs = append(Plugins.Inputs, pluginWrapper.(io.Reader))
-	}
-
-	if isW {
-		Plugins.Outputs = append(Plugins.Outputs, pluginWrapper.(io.Writer))
-	}
+	Plugins = append(Plugins, pluginWrapper)
 }
 
 // InitPlugins specify and initialize all available plugins
@@ -115,4 +101,20 @@ func InitPlugins() {
 	for _, options := range Settings.outputHTTP {
 		registerPlugin(NewHTTPOutput, options, &Settings.outputHTTPConfig)
 	}
+}
+
+func testPlugins(plugins ...interface{}) {
+	resetPlugins()
+
+	Plugins = plugins
+}
+
+func resetPlugins() {
+	for _, plugin := range Plugins {
+		if c, isC := plugin.(io.Closer); isC {
+			c.Close()
+		}
+	}
+
+	Plugins = make([]interface{}, 0)
 }

--- a/plugins.go
+++ b/plugins.go
@@ -101,6 +101,10 @@ func InitPlugins() {
 		registerPlugin(NewHTTPOutput, options, &Settings.outputHTTPConfig)
 	}
 
+	if !Settings.modifierConfig.IsEmpty() {
+		Middleware = append(Middleware, NewHTTPModifier(&Settings.modifierConfig))
+	}
+
 	for _, cmd := range Settings.middleware {
 		Middleware = append(Middleware, NewExternalMiddleware(cmd))
 	}

--- a/plugins.go
+++ b/plugins.go
@@ -7,10 +7,9 @@ import (
 	"time"
 )
 
-type plugins []interface{}
-
 // Plugins holds all the plugin objects
-var Plugins plugins
+var Plugins []interface{}
+var Middleware []io.ReadWriter
 
 // extractLimitOptions detects if plugin get called with limiter support
 // Returns address and limit
@@ -100,6 +99,10 @@ func InitPlugins() {
 
 	for _, options := range Settings.outputHTTP {
 		registerPlugin(NewHTTPOutput, options, &Settings.outputHTTPConfig)
+	}
+
+	for _, cmd := range Settings.middleware {
+		Middleware = append(Middleware, NewExternalMiddleware(cmd))
 	}
 }
 

--- a/plugins.go
+++ b/plugins.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"io"
 	"reflect"
 	"strings"
 	"time"
-	"io"
 )
 
 type plugins []interface{}

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -1,42 +1,37 @@
 package main
 
 import (
-	"io"
 	"testing"
 )
 
 func TestPluginsRegistration(t *testing.T) {
-	Plugins.Inputs = []io.Reader{}
-	Plugins.Outputs = []io.Writer{}
+	Plugins = make([]interface{}, 0)
 
 	Settings.inputDummy = MultiOption{"[]"}
 	Settings.outputDummy = MultiOption{"[]"}
-	Settings.outputHTTP = MultiOption{"www.example.com|10"}
 	Settings.inputFile = MultiOption{"/dev/null"}
+	Settings.outputHTTP = MultiOption{"www.example.com|10"}
+
 
 	InitPlugins()
 
-	if len(Plugins.Inputs) != 2 {
-		t.Errorf("Should be 2 inputs %d", len(Plugins.Inputs))
+	if len(Plugins) != 4 {
+		t.Errorf("Should be 2 inputs and 2 outputs %d", len(Plugins))
 	}
 
-	if _, ok := Plugins.Inputs[0].(*DummyInput); !ok {
+	if _, ok := Plugins[0].(*DummyInput); !ok {
 		t.Errorf("First input should be DummyInput")
 	}
 
-	if _, ok := Plugins.Inputs[1].(*FileInput); !ok {
-		t.Errorf("Second input should be FileInput")
-	}
-
-	if len(Plugins.Outputs) != 2 {
-		t.Errorf("Should be 2 output %d", len(Plugins.Outputs))
-	}
-
-	if _, ok := Plugins.Outputs[0].(*DummyOutput); !ok {
+	if _, ok := Plugins[1].(*DummyOutput); !ok {
 		t.Errorf("First output should be DummyOutput")
 	}
 
-	if l, ok := Plugins.Outputs[1].(*Limiter); ok {
+	if _, ok := Plugins[2].(*FileInput); !ok {
+		t.Errorf("Second input should be FileInput")
+	}
+
+	if l, ok := Plugins[3].(*Limiter); ok {
 		if _, ok := l.plugin.(*HTTPOutput); !ok {
 			t.Errorf("HTTPOutput should be wrapped in limiter")
 		}

--- a/plugins_test.go
+++ b/plugins_test.go
@@ -12,7 +12,6 @@ func TestPluginsRegistration(t *testing.T) {
 	Settings.inputFile = MultiOption{"/dev/null"}
 	Settings.outputHTTP = MultiOption{"www.example.com|10"}
 
-
 	InitPlugins()
 
 	if len(Plugins) != 4 {

--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -99,7 +99,7 @@ func (t *Listener) listen() {
 		case packet := <-t.packetsChan:
 			t.processTCPPacket(packet)
 
-		case <- gcTicker:
+		case <-gcTicker:
 			now := time.Now()
 
 			for _, message := range t.messages {

--- a/settings.go
+++ b/settings.go
@@ -43,7 +43,7 @@ type AppSettings struct {
 
 	inputRAW MultiOption
 
-	middleware string
+	middleware MultiOption
 
 	inputHTTP  MultiOption
 	outputHTTP MultiOption
@@ -82,7 +82,7 @@ func init() {
 
 	flag.Var(&Settings.inputRAW, "input-raw", "Capture traffic from given port (use RAW sockets and require *sudo* access):\n\t# Capture traffic from 8080 port\n\tgor --input-raw :8080 --output-http staging.com")
 
-	flag.StringVar(&Settings.middleware, "middleware", "", "Used for modifying traffic using external command")
+	flag.Var(&Settings.middleware, "middleware", "Used for modifying traffic using external command")
 
 	flag.Var(&Settings.inputHTTP, "input-http", "Read requests from HTTP, should be explicitly sent from your application:\n\t# Listen for http on 9000\n\tgor --input-http :9000 --output-http staging.com")
 

--- a/settings.go
+++ b/settings.go
@@ -139,3 +139,11 @@ func Debug(args ...interface{}) {
 		fmt.Println(args...)
 	}
 }
+
+func stringLimit(buf []byte) string {
+	if len(buf) > 500 {
+		return string(buf[:500])
+	}
+
+	return string(buf)
+}

--- a/test_input.go
+++ b/test_input.go
@@ -14,7 +14,7 @@ type TestInput struct {
 // NewTestInput constructor for TestInput
 func NewTestInput() (i *TestInput) {
 	i = new(TestInput)
-	i.data = make(chan []byte, 100)
+	i.data = make(chan []byte, 1)
 
 	return
 }


### PR DESCRIPTION
With recent middleware changes borders between readers and writers have blurred (in terms of go interfaces), for example http output now reader as well, because it provides response reading.
First goal is to store all plugins as interfaces and treat them based on their capabilities using interface checks.

Second allowing multiple middleware which act as pipeline, and adding converting http modifier to internal middleware.

