### PR TITLE
Handle headers added by bad clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@
 *.class
 
 *.test
-
+.idea
 gor

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ drace:
 	docker run -v `pwd`:$(SOURCE_PATH) -t -i --env GORACE="halt_on_error=1" gor go test ./... $(ARGS) -v -race -timeout 15s
 
 dtest:
-	docker run -v `pwd`:$(SOURCE_PATH) -t -i gor go test ./ -timeout 60s $(ARGS) -v
+	docker run -v `pwd`:$(SOURCE_PATH) -t -i gor go test ./... -timeout 60s $(ARGS) -v
 
 dcover:
 	docker run -v `pwd`:$(SOURCE_PATH) -t -i --env GORACE="halt_on_error=1" gor go test $(ARGS) -race -v -timeout 15s -coverprofile=coverage.out

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -55,7 +55,13 @@ func header(payload []byte, name []byte) (value []byte, headerStart, valueStart,
 	if payload[valueStart] == ' ' {          // Ignore empty space after ':'
 		valueStart++
 	}
-	headerEnd = valueStart + bytes.IndexByte(payload[valueStart:], '\r')
+
+	headerEnd = valueStart + bytes.IndexByte(payload[valueStart:], '\n')
+
+	if payload[headerEnd - 1] == '\r' {
+		headerEnd -= 1
+	}
+
 	value = payload[valueStart:headerEnd]
 
 	return

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -9,18 +9,36 @@ func TestHeader(t *testing.T) {
 	var payload, val []byte
 	var headerStart int
 
+	// Value with space at start
 	payload = []byte("POST /post HTTP/1.1\r\nContent-Length: 7\r\nHost: www.w3.org\r\n\r\na=1&b=2")
 
 	if val = Header(payload, []byte("Content-Length")); !bytes.Equal(val, []byte("7")) {
 		t.Error("Should find header value")
 	}
 
+	// Value without space at start
 	payload = []byte("POST /post HTTP/1.1\r\nContent-Length:7\r\nHost: www.w3.org\r\n\r\na=1&b=2")
 
 	if val = Header(payload, []byte("Content-Length")); !bytes.Equal(val, []byte("7")) {
 		t.Error("Should find header value without space after :")
 	}
 
+	// Value is empty
+	payload = []byte("GET /p HTTP/1.1\r\nCookie:\r\nHost: www.w3.org\r\n\r\n")
+
+	if val = Header(payload, []byte("Cookie")); len(val) > 0 {
+		t.Error("Should return empty value")
+	}
+
+	// Wrong delimeter
+	payload = []byte("GET /p HTTP/1.1\r\nCookie: 123\nHost: www.w3.org\r\n\r\n")
+
+	if val = Header(payload, []byte("Cookie")); !bytes.Equal(val, []byte("123")) {
+		t.Error("Should handle wrong header delimeter")
+	}
+
+
+	// Header not found
 	if _, headerStart, _, _ = header(payload, []byte("Not-Found")); headerStart != -1 {
 		t.Error("Should not found header")
 	}


### PR DESCRIPTION
Handle headers which ends only with `\n` without `\r`.

Fix https://github.com/buger/gor/issues/208

Binaries:
https://www.dropbox.com/s/yd3weebfpmdt57f/gor_non_rfc_headers_x64.tar.gz?dl=1
https://www.dropbox.com/s/yd3weebfpmdt57f/gor_non_rfc_headers_x32.tar.gz?dl=1