### PR TITLE
Fixes a panic in TCPMessage with small packets

### DIFF
--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -92,9 +92,14 @@ func (t *TCPMessage) IsMultipart() bool {
 	}
 
 	payload := t.packets[0].Data
-	m := payload[:4]
 
 	if t.IsIncoming {
+		m := payload[:]
+
+		if len(payload) >= 4 {
+			m = payload[:4]
+		}
+
 		// If one GET, OPTIONS, or HEAD request
 		if bytes.Equal(m, []byte("GET ")) || bytes.Equal(m, []byte("OPTI")) || bytes.Equal(m, []byte("HEAD")) {
 			return false

--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -93,13 +93,13 @@ func (t *TCPMessage) IsMultipart() bool {
 
 	payload := t.packets[0].Data
 
+	if len(payload) < 4 {
+		return false
+	}
+
+	m := payload[:4]
+
 	if t.IsIncoming {
-		m := payload[:]
-
-		if len(payload) >= 4 {
-			m = payload[:4]
-		}
-
 		// If one GET, OPTIONS, or HEAD request
 		if bytes.Equal(m, []byte("GET ")) || bytes.Equal(m, []byte("OPTI")) || bytes.Equal(m, []byte("HEAD")) {
 			return false


### PR DESCRIPTION
Every packet which had 4 bytes of data or less was
causing a panic - slice bounds out of range.

Closes #215