### PR TITLE
Replaying requests for large files

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -40,7 +40,7 @@ func (rtc readTimeOutConn) Read(b []byte) (int, error) {
 	for {
 		nextRead := readPieceSize
 
-		if nextRead > (shouldRead - n) {
+		if nextRead+n > shouldRead {
 			nextRead = shouldRead - n
 		}
 
@@ -51,6 +51,10 @@ func (rtc readTimeOutConn) Read(b []byte) (int, error) {
 
 		if err != nil {
 			return n, err
+		}
+
+		if n >= shouldRead {
+			return n, nil
 		}
 
 	}

--- a/http_client.go
+++ b/http_client.go
@@ -58,8 +58,6 @@ func (rtc readTimeOutConn) Read(b []byte) (int, error) {
 		}
 
 	}
-
-	return n, io.EOF
 }
 
 type HTTPClientConfig struct {
@@ -213,7 +211,7 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 		}
 		toConn.readTimeout = c.config.Timeout
 
-		var readBytes int64 = 0
+		var readBytes int64
 
 		for {
 			if n, err := io.CopyN(ioutil.Discard, toConn, readPieceSize); err == io.EOF {

--- a/http_client.go
+++ b/http_client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"github.com/buger/gor/proto"
 	"io"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/url"
@@ -158,6 +159,12 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 	//
 	// See https://github.com/buger/gor/issues/184
 	if n == len(c.respBuf) {
+
+		_, errBody := ioutil.ReadAll(c.conn)
+		if errBody != nil {
+			Debug("[HTTPClient] Read the whole body error:", errBody, c.baseURL)
+		}
+
 		c.Disconnect()
 	}
 

--- a/output_http.go
+++ b/output_http.go
@@ -184,6 +184,12 @@ func (o *HTTPOutput) Read(data []byte) (int, error) {
 
 func (o *HTTPOutput) sendRequest(client *HTTPClient, request []byte) {
 	meta := payloadMeta(request)
+
+	if len(meta) < 2 {
+		// Malformed request
+		return
+	}
+
 	uuid := meta[1]
 
 	body := payloadBody(request)

--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -92,9 +92,14 @@ func (t *TCPMessage) IsMultipart() bool {
 	}
 
 	payload := t.packets[0].Data
-	m := payload[:4]
 
 	if t.IsIncoming {
+		m := payload[:]
+
+		if len(payload) >= 4 {
+			m = payload[:4]
+		}
+
 		// If one GET, OPTIONS, or HEAD request
 		if bytes.Equal(m, []byte("GET ")) || bytes.Equal(m, []byte("OPTI")) || bytes.Equal(m, []byte("HEAD")) {
 			return false

--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -93,13 +93,13 @@ func (t *TCPMessage) IsMultipart() bool {
 
 	payload := t.packets[0].Data
 
+	if len(payload) < 4 {
+		return false
+	}
+
+	m := payload[:4]
+
 	if t.IsIncoming {
-		m := payload[:]
-
-		if len(payload) >= 4 {
-			m = payload[:4]
-		}
-
 		// If one GET, OPTIONS, or HEAD request
 		if bytes.Equal(m, []byte("GET ")) || bytes.Equal(m, []byte("OPTI")) || bytes.Equal(m, []byte("HEAD")) {
 			return false


### PR DESCRIPTION
I wanted to use `gor` for testing [a HTTP server](https://github.com/ironsmile/nedomi) while mirroring real traffic. Unfortunately the traffic was for relatively big media files (from 100MB up to few GBs). In that case the buffer for reading the response body was too small and `gor` replayer was failing to replicate the load which real users are generating on the mirrored server.

An other limitation was the fixed deadline for reading the response body. With very large files a timeout of 5s, 30s or whatever is not practical as very big files can take some time to be downloaded. On the other hand a relatively small timeout is required to stop stalled connections which do not move any data around anymore. Maybe because of a faulty HTTP server under test, network problems or something else.

This pull request aims to remedy both of the problems. It does it by

* Reading the "whole" body of the response. Or at least trying to do so. The reading is done in small chunks which are discarded instantly in order not to consume too much memory for large responses. An upper limit of the read data is still present to make sure a faulty server will not create an never ending chunked response or some other problem of the kind.

* Instead of a fixed deadline, a rolling timeout is introduced while reading the response. The connection will timeout only if there is no network activity at all for the set amount of time.

* The behaviour regarding small files is not changed in any way.

* Fixes few crashes which were happening from time to time during prolonged tests.