### PR TITLE
fix crash on missing payload metadata

### DIFF
--- a/input_file.go
+++ b/input_file.go
@@ -61,7 +61,7 @@ func (i *FileInput) emit() {
 		buf := scanner.Bytes()
 		meta := payloadMeta(buf)
 
-		if meta[0][0] == RequestPayload {
+		if len(meta) > 2 && meta[0][0] == RequestPayload {
 			ts, _ := strconv.ParseInt(string(meta[2]), 10, 64)
 
 			if lastTime != 0 {

--- a/output_http.go
+++ b/output_http.go
@@ -184,6 +184,9 @@ func (o *HTTPOutput) Read(data []byte) (int, error) {
 
 func (o *HTTPOutput) sendRequest(client *HTTPClient, request []byte) {
 	meta := payloadMeta(request)
+	if len(meta) < 2 {
+		return
+	}
 	uuid := meta[1]
 
 	body := payloadBody(request)

--- a/protocol.go
+++ b/protocol.go
@@ -67,6 +67,9 @@ func payloadBody(payload []byte) []byte {
 
 func payloadMeta(payload []byte) [][]byte {
 	headerSize := bytes.IndexByte(payload, '\n')
+        if headerSize < 0 {
+                headerSize = 0;
+	}
 	return bytes.Split(payload[:headerSize], []byte{' '})
 }
 

--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -92,6 +92,11 @@ func (t *TCPMessage) IsMultipart() bool {
 	}
 
 	payload := t.packets[0].Data
+
+	if len(payload) < 4 {
+		return true
+	}
+
 	m := payload[:4]
 
 	if t.IsIncoming {


### PR DESCRIPTION
Fix a crash we encountered.

This also includes fix found in https://github.com/buger/gor/pull/216 and https://github.com/buger/gor/pull/211 (neither of which have been merged)