### PR TITLE
Handle middleware failures

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -47,7 +47,11 @@ func NewMiddleware(command string) *Middleware {
 			log.Fatal(err)
 		}
 
-		cmd.Wait()
+		err = cmd.Wait()
+
+		if err != nil {
+			log.Fatal(err)
+		}
 	}()
 
 	return m


### PR DESCRIPTION
Without this the middleware might crash silently and gor keeps running