### PR TITLE
handle broken pipe error

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -102,7 +102,10 @@ func (c *HTTPClient) isAlive() bool {
 	// Ready 1 byte from socket without timeout to check if it not closed
 	c.conn.SetReadDeadline(time.Now().Add(time.Millisecond))
 	_, err := c.conn.Read(one)
-	if err == io.EOF {
+
+	if err == nil {
+		return true
+	} else if err == io.EOF {
 		return false
 	} else if strings.Contains(err.Error(), "connection reset by peer") {
 		Debug("Detected broken pipe.", err)

--- a/http_client.go
+++ b/http_client.go
@@ -101,7 +101,11 @@ func (c *HTTPClient) isAlive() bool {
 
 	// Ready 1 byte from socket without timeout to check if it not closed
 	c.conn.SetReadDeadline(time.Now().Add(time.Millisecond))
-	if _, err := c.conn.Read(one); err == io.EOF {
+	_, err := c.conn.Read(one)
+	if err == io.EOF {
+		return false
+	} else if strings.Contains(err.Error(), "connection reset by peer") {
+		Debug("Detected broken pipe.", err)
 		return false
 	}
 


### PR DESCRIPTION
If gor http output is sent via a firewall which is configured to terminate idle connection after a few minutes,  this can lead to a "broken pipe" error after a period of inactivity.
Enhancing the isAlive check to identify connections that have been closed by a peer forces a reconnect.