### PR TITLE
Fix middleware bug

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -84,7 +84,7 @@ func (m *Middleware) copy(to io.Writer, from io.Reader) {
 	}
 }
 
-func (m *Middleware) read(from io.Reader) {
+func (m *Middleware) readData(from io.Reader) (err error) {
 	scanner := bufio.NewScanner(from)
 
 	for scanner.Scan() {
@@ -103,9 +103,19 @@ func (m *Middleware) read(from io.Reader) {
 
 	if err := scanner.Err(); err != nil {
 		fmt.Fprintln(os.Stderr, "Traffic modifier command failed:", err)
+		return err
 	}
 
-	return
+	return nil
+}
+
+func (m *Middleware) read(from io.Reader) {
+	for {
+		err := m.readData(from)
+		if err != nil {
+			continue
+		}
+	}
 }
 
 func (m *Middleware) Read(data []byte) (int, error) {


### PR DESCRIPTION
Middleware goroutine "go m.read(m.Stdout)" will exit when scanner error for a large request (>32K), and so will read no content from middleware anymore.

I added a for loop , catching the error in the loop and continue . Avoid the goroutine exit.
