### PR TITLE
Improve Http client compilance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ run:
 	$(RUN) go run $(LDFLAGS) $(SOURCE) --input-dummy=0 --output-http="http://localhost:9000" --input-raw 127.0.0.1:9000 --input-http 127.0.0.1:9000 --verbose --debug --middleware "./examples/middleware/echo.sh"
 
 run-2:
-	$(RUN) go run $(SOURCE) --input-file ./fixtures/requests.gor --output-dummy=0
+	sudo -E go run $(SOURCE) --input-raw :8000 --output-http "http://localhost:8001" --verbose --output-http-workers 1
 
 record:
 	$(RUN) go run $(SOURCE) --input-dummy=0 --output-file=requests.gor --verbose --debug

--- a/http_client.go
+++ b/http_client.go
@@ -13,9 +13,16 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"bytes"
 )
 
 var httpMu sync.Mutex
+
+const (
+	readChunkSize   = 64*1024
+	maxResponseSize = 1073741824
+)
+var chunkedSuffix []byte = []byte("0\r\n\r\n")
 
 var defaultPorts = map[string]string{
 	"http":  "80",
@@ -56,6 +63,8 @@ func NewHTTPClient(baseURL string, config *HTTPClientConfig) *HTTPClient {
 	if config.Timeout.Nanoseconds() == 0 {
 		config.Timeout = 5 * time.Second
 	}
+
+	config.ConnectionTimeout = time.Second
 
 	if config.ResponseBufferSize == 0 {
 		config.ResponseBufferSize = 100 * 1024 // 100kb
@@ -160,27 +169,115 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 		return
 	}
 
-	c.conn.SetReadDeadline(timeout)
-	n, err := c.conn.Read(c.respBuf)
+	var readBytes, n int
+	var currentChunk []byte
+	timeout = time.Now().Add(c.config.Timeout)
+	chunked := false
+	contentLength := -1
+	currentContentLength := 0
+	chunks := 0
 
-	// If response large then our buffer, we need to read all response buffer
-	// Otherwise it will corrupt response of next request
-	// Parsing response body is non trivial thing, especially with keep-alive
-	// Simples case is to to close connection if response too large
-	//
-	// See https://github.com/buger/gor/issues/184
-	if n == len(c.respBuf) {
-		c.Disconnect()
+	for {
+		c.conn.SetReadDeadline(timeout)
+
+		if readBytes < len(c.respBuf) {
+			n, err = c.conn.Read(c.respBuf[readBytes:])
+			readBytes += n
+			chunks++
+
+			if err != nil {
+				if err == io.EOF {
+					err = nil
+				}
+				break
+			}
+
+			// First chunk
+			if (chunked || contentLength != -1) {
+				currentContentLength += n
+			} else {
+				if bytes.Equal(proto.Header(c.respBuf, []byte("Transfer-Encoding")), []byte("chunked")) {
+					chunked = true
+				} else {
+					l := proto.Header(c.respBuf, []byte("Content-Length"))
+					if len(l) > 0 {
+						contentLength, _ = strconv.Atoi(string(l))
+					}
+				}
+
+				currentContentLength += len(proto.Body(c.respBuf))
+			}
+
+	        if chunked {
+	        	// Check if chunked message finished
+	        	if bytes.HasSuffix(c.respBuf[:readBytes], chunkedSuffix) {
+	        		break
+	        	}
+	        } else if contentLength != -1 {
+	        	if currentContentLength > contentLength {
+	        		c.Disconnect()
+	        		break
+	        	} else if currentContentLength == contentLength {
+	        		break
+	        	}
+	        }
+		} else {
+			if currentChunk == nil {
+				currentChunk = make([]byte, readChunkSize)
+			}
+
+			n, err = c.conn.Read(currentChunk)
+
+			if err == io.EOF {
+        		break
+        	} else if err != nil {
+        		Debug("[HTTPClient] Read the whole body error:", err, c.baseURL)
+        		break
+        	}
+
+	        readBytes += int(n)
+	        chunks++
+	        currentContentLength += n
+
+	        if chunked {
+	        	// Check if chunked message finished
+	        	if bytes.HasSuffix(currentChunk[:n], chunkedSuffix) {
+	        		break
+	        	}
+	        } else if contentLength != -1 {
+	        	if currentContentLength > contentLength {
+	        		c.Disconnect()
+	        		break
+	        	} else if currentContentLength == contentLength {
+	        		break
+	        	}
+	        } else {
+	        	c.Disconnect()
+	        	break
+	        }
+	    }
+
+	    if readBytes >= maxResponseSize {
+	        Debug("[HTTPClient] Body is more than the max size", maxResponseSize,
+	            c.baseURL)
+	        break
+	    }
+
+	    // For following chunks expect less timeout
+	    timeout = time.Now().Add(c.config.Timeout / 5)
 	}
 
 	if err != nil {
-		Debug("[HTTPClient] Response read error", err, c.conn)
+		Debug("[HTTPClient] Response read error", err, c.conn, readBytes)
 		response = errorPayload(HTTP_TIMEOUT)
 		return
 	}
 
-	payload := make([]byte, n)
-	copy(payload, c.respBuf[:n])
+	if readBytes > len(c.respBuf) {
+		readBytes = len(c.respBuf)
+	}
+	payload := make([]byte, readBytes)
+	copy(payload, c.respBuf[:readBytes])
 
 	if c.config.Debug {
 		Debug("[HTTPClient] Received:", string(payload))

--- a/http_client.go
+++ b/http_client.go
@@ -23,7 +23,7 @@ const (
 	maxResponseSize = 1073741824
 )
 
-var chunkedSuffix []byte("0\r\n\r\n")
+var chunkedSuffix = []byte("0\r\n\r\n")
 
 var defaultPorts = map[string]string{
 	"http":  "80",

--- a/http_client.go
+++ b/http_client.go
@@ -23,7 +23,7 @@ const (
 	maxResponseSize = 1073741824
 )
 
-var chunkedSuffix []byte = []byte("0\r\n\r\n")
+var chunkedSuffix []byte("0\r\n\r\n")
 
 var defaultPorts = map[string]string{
 	"http":  "80",

--- a/http_client_test.go
+++ b/http_client_test.go
@@ -90,22 +90,22 @@ func TestHTTPClientSend(t *testing.T) {
 // https://github.com/buger/gor/issues/184
 func TestHTTPClientResponseBuffer(t *testing.T) {
 	testCases := []struct {
-		name string
-        responseSize int
-        buffserSize int
-        expectedSize int
-        timeout time.Duration
-    }{
-    	{ "Chunked, buffer overflow", 10 * 1024, 1024, 1024, 50*time.Millisecond },
+		name         string
+		responseSize int
+		buffserSize  int
+		expectedSize int
+		timeout      time.Duration
+	}{
+		{"Chunked, buffer overflow", 10 * 1024, 1024, 1024, 50 * time.Millisecond},
 
-    	{ "Chunked, fits buffer", 10 * 1024, 64 * 1024, 10*1024 + 145 /* headers length + chunked meta */, 50*time.Millisecond },
+		{"Chunked, fits buffer", 10 * 1024, 64 * 1024, 10*1024 + 145 /* headers length + chunked meta */, 50 * time.Millisecond},
 
-    	{ "Content-Length, buffer overflow", 1024, 1000, 1000, 50*time.Millisecond },
+		{"Content-Length, buffer overflow", 1024, 1000, 1000, 50 * time.Millisecond},
 
-    	{ "Content-Length, fits buffer", 1024, 64 * 1024, 1024 + 118, 50*time.Millisecond },
-    }
+		{"Content-Length, fits buffer", 1024, 64 * 1024, 1024 + 118, 50 * time.Millisecond},
+	}
 
-    for _, tc := range testCases {
+	for _, tc := range testCases {
 		wg := new(sync.WaitGroup)
 
 		payload := []byte("GET / HTTP/1.1\r\n\r\n")
@@ -402,26 +402,6 @@ func TestHTTPClientErrors(t *testing.T) {
 	defer ln1.Close()
 
 	client = NewHTTPClient("http://"+ln1.Addr().String(), &HTTPClientConfig{Debug: true, Timeout: 10 * time.Millisecond})
-
-	if resp, err := client.Send(req); err != nil {
-		if s := proto.Status(resp); !bytes.Equal(s, []byte("524")) {
-			t.Error("Should return status 524 for connection reset by peer, instead:", string(s))
-		}
-	} else {
-		t.Error("Should throw error")
-	}
-
-	ln2, _ := net.Listen("tcp", "127.0.0.1:0")
-	go func() {
-		buf := make([]byte, 64*1024)
-		conn, _ := ln2.Accept()
-
-		conn.Read(buf)
-		defer conn.Close()
-	}()
-	defer ln2.Close()
-
-	client = NewHTTPClient("http://"+ln2.Addr().String(), &HTTPClientConfig{Debug: true, Timeout: 10 * time.Millisecond})
 
 	if resp, err := client.Send(req); err != nil {
 		if s := proto.Status(resp); !bytes.Equal(s, []byte("524")) {

--- a/input_dummy.go
+++ b/input_dummy.go
@@ -35,7 +35,7 @@ func (i *DummyInput) emit() {
 		case <-ticker.C:
 			uuid := uuid()
 			reqh := payloadHeader(RequestPayload, uuid, time.Now().UnixNano())
-			i.data <- append(reqh, []byte("GET /HTTP/1.1\r\nHost: www.w3.org\r\nUser-Agent: Go 1.1 package http\r\nAccept-Encoding: gzip\r\n\r\n")...)
+			i.data <- append(reqh, []byte("GET / HTTP/1.1\r\nHost: www.w3.org\r\nUser-Agent: Go 1.1 package http\r\nAccept-Encoding: gzip\r\n\r\n")...)
 
 			resh := payloadHeader(ResponsePayload, uuid, 1)
 			i.data <- append(resh, []byte("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")...)

--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -22,12 +22,12 @@ import (
 	"io"
 	"log"
 	"net"
+	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-	"runtime"
 )
 
 var _ = fmt.Println
@@ -275,7 +275,7 @@ func (t *Listener) readPcap() {
 
 	bpfSupported := true
 	if runtime.GOOS == "darwin" {
- 	   bpfSupported = false
+		bpfSupported = false
 	}
 
 	var wg sync.WaitGroup

--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -221,6 +221,10 @@ type DeviceNotFoundError struct {
 func (e *DeviceNotFoundError) Error() string {
 	devices, _ := pcap.FindAllDevs()
 
+	if len(devices) == 0 {
+		return "Can't get list of network interfaces, ensure that you running Gor as root user or sudo.\nTo run as non-root users see this docs https://github.com/buger/gor/wiki/Running-as-non-root-user"
+	}
+
 	var msg string
 	msg += "Can't find interfaces with addr: " + e.addr + ". Provide available IP for intercepting traffic: \n"
 	for _, device := range devices {

--- a/raw_socket_listener/tcp_packet.go
+++ b/raw_socket_listener/tcp_packet.go
@@ -2,9 +2,9 @@ package rawSocket
 
 import (
 	"encoding/binary"
+	"log"
 	"strconv"
 	"strings"
-	"log"
 )
 
 var _ = log.Println


### PR DESCRIPTION
* Properly handle responses which consist from multiple tcp parts. 
* Know when HTTP response ends (support chunked and content-length checks)
* Fully read tcp buffer before starting new request

Should fix #217 and #247 
