### PR TITLE
Do not track response by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ profile_test:
 
 # Used mainly for debugging, because docker container do not have access to parent machine ports
 run:
-	$(RUN) go run $(LDFLAGS) $(SOURCE) --input-dummy=0 --output-http="http://localhost:9000" --input-raw 127.0.0.1:9000 --input-http 127.0.0.1:9000 --verbose --debug --middleware "./examples/middleware/echo.sh"
+	$(RUN) go run $(LDFLAGS) $(SOURCE) --input-dummy=0 --output-http="http://localhost:9000" --input-raw-track-response --input-raw 127.0.0.1:9000 --input-http 127.0.0.1:9000 --verbose --debug --middleware "./examples/middleware/echo.sh"
 
 run-2:
 	sudo -E go run $(SOURCE) --input-raw :8000 --output-http "http://localhost:8001" --verbose --output-http-workers 1

--- a/input_raw.go
+++ b/input_raw.go
@@ -9,13 +9,13 @@ import (
 
 // RAWInput used for intercepting traffic for given address
 type RAWInput struct {
-	data     chan *raw.TCPMessage
-	address  string
-	expire   time.Duration
-	quit     chan bool
-	engine   int
+	data          chan *raw.TCPMessage
+	address       string
+	expire        time.Duration
+	quit          chan bool
+	engine        int
 	trackResponse bool
-	listener *raw.Listener
+	listener      *raw.Listener
 }
 
 // Available engines for intercepting traffic

--- a/input_raw.go
+++ b/input_raw.go
@@ -14,6 +14,7 @@ type RAWInput struct {
 	expire   time.Duration
 	quit     chan bool
 	engine   int
+	trackResponse bool
 	listener *raw.Listener
 }
 
@@ -24,13 +25,14 @@ const (
 )
 
 // NewRAWInput constructor for RAWInput. Accepts address with port as argument.
-func NewRAWInput(address string, engine int, expire time.Duration) (i *RAWInput) {
+func NewRAWInput(address string, engine int, trackResponse bool, expire time.Duration) (i *RAWInput) {
 	i = new(RAWInput)
 	i.data = make(chan *raw.TCPMessage)
 	i.address = address
 	i.expire = expire
 	i.engine = engine
 	i.quit = make(chan bool)
+	i.trackResponse = trackResponse
 
 	i.listen(address)
 	i.listener.IsReady()
@@ -65,7 +67,7 @@ func (i *RAWInput) listen(address string) {
 		log.Fatal("input-raw: error while parsing address", err)
 	}
 
-	i.listener = raw.NewListener(host, port, i.engine, i.expire)
+	i.listener = raw.NewListener(host, port, i.engine, i.trackResponse, i.expire)
 
 	ch := i.listener.Receiver()
 

--- a/input_raw_test.go
+++ b/input_raw_test.go
@@ -42,7 +42,7 @@ func TestRAWInput(t *testing.T) {
 
 	var respCounter, reqCounter int64
 
-	input := NewRAWInput(originAddr, EnginePcap, testRawExpire)
+	input := NewRAWInput(originAddr, EnginePcap, true, testRawExpire)
 	defer input.Close()
 
 	output := NewTestOutput(func(data []byte) {
@@ -97,7 +97,7 @@ func TestRAWInputIPv6(t *testing.T) {
 
 	var respCounter, reqCounter int64
 
-	input := NewRAWInput(originAddr, EnginePcap, testRawExpire)
+	input := NewRAWInput(originAddr, EnginePcap, true, testRawExpire)
 	defer input.Close()
 
 	output := NewTestOutput(func(data []byte) {
@@ -148,7 +148,7 @@ func TestInputRAW100Expect(t *testing.T) {
 
 	originAddr := strings.Replace(origin.Listener.Addr().String(), "[::]", "127.0.0.1", -1)
 
-	input := NewRAWInput(originAddr, EnginePcap, time.Second)
+	input := NewRAWInput(originAddr, EnginePcap, true, time.Second)
 	defer input.Close()
 
 	// We will use it to get content of raw HTTP request
@@ -211,7 +211,7 @@ func TestInputRAWChunkedEncoding(t *testing.T) {
 	}))
 
 	originAddr := strings.Replace(origin.Listener.Addr().String(), "[::]", "127.0.0.1", -1)
-	input := NewRAWInput(originAddr, EnginePcap, time.Second)
+	input := NewRAWInput(originAddr, EnginePcap, true, time.Second)
 	defer input.Close()
 
 	replay := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -275,7 +275,7 @@ func TestInputRAWLargePayload(t *testing.T) {
 	}))
 	originAddr := strings.Replace(origin.Listener.Addr().String(), "[::]", "127.0.0.1", -1)
 
-	input := NewRAWInput(originAddr, EnginePcap, testRawExpire)
+	input := NewRAWInput(originAddr, EnginePcap, true, testRawExpire)
 	defer input.Close()
 
 	replay := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -320,7 +320,7 @@ func BenchmarkRAWInput(b *testing.B) {
 
 	var respCounter, reqCounter int64
 
-	input := NewRAWInput(originAddr, EnginePcap, testRawExpire)
+	input := NewRAWInput(originAddr, EnginePcap, true, testRawExpire)
 	defer input.Close()
 
 	output := NewTestOutput(func(data []byte) {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -117,7 +117,7 @@ func TestEchoMiddleware(t *testing.T) {
 
 	// Catch traffic from one service
 	fromAddr := strings.Replace(from.Listener.Addr().String(), "[::]", "127.0.0.1", -1)
-	input := NewRAWInput(fromAddr, EnginePcap, testRawExpire)
+	input := NewRAWInput(fromAddr, EnginePcap, true, testRawExpire)
 	defer input.Close()
 
 	// And redirect to another
@@ -179,7 +179,7 @@ func TestTokenMiddleware(t *testing.T) {
 
 	fromAddr := strings.Replace(from.Listener.Addr().String(), "[::]", "127.0.0.1", -1)
 	// Catch traffic from one service
-	input := NewRAWInput(fromAddr, EnginePcap, testRawExpire)
+	input := NewRAWInput(fromAddr, EnginePcap, true, testRawExpire)
 	defer input.Close()
 
 	// And redirect to another

--- a/plugins.go
+++ b/plugins.go
@@ -94,7 +94,7 @@ func InitPlugins() {
 	}
 
 	for _, options := range Settings.inputRAW {
-		registerPlugin(NewRAWInput, options, engine, time.Duration(0))
+		registerPlugin(NewRAWInput, options, engine, Settings.inputRAWTrackResponse, time.Duration(0))
 	}
 
 	for _, options := range Settings.inputTCP {

--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -206,10 +206,10 @@ func (t *TCPMessage) UpdateResponseAck() uint32 {
 		t.ResponseAck = lastPacket.Seq + uint32(len(lastPacket.Data))
 
 		// We swappwed src and dst port
-		copy(t.ResponseID[:4], lastPacket.Addr)
-		copy(t.ResponseID[4:], lastPacket.Raw[2:4]) // Src port
-		copy(t.ResponseID[6:], lastPacket.Raw[0:2]) // Dest port
-		binary.BigEndian.PutUint32(t.ResponseID[8:12], t.ResponseAck)
+		copy(t.ResponseID[:16], lastPacket.Addr)
+		copy(t.ResponseID[16:], lastPacket.Raw[2:4]) // Src port
+		copy(t.ResponseID[18:], lastPacket.Raw[0:2]) // Dest port
+		binary.BigEndian.PutUint32(t.ResponseID[20:24], t.ResponseAck)
 	}
 
 	return t.ResponseAck

--- a/settings.go
+++ b/settings.go
@@ -43,6 +43,7 @@ type AppSettings struct {
 
 	inputRAW       MultiOption
 	inputRAWEngine string
+	inputRAWTrackResponse bool
 
 	middleware string
 
@@ -82,6 +83,8 @@ func init() {
 	flag.Var(&Settings.outputFile, "output-file", "Write incoming requests to file: \n\tgor --input-raw :80 --output-file ./requests.gor")
 
 	flag.Var(&Settings.inputRAW, "input-raw", "Capture traffic from given port (use RAW sockets and require *sudo* access):\n\t# Capture traffic from 8080 port\n\tgor --input-raw :8080 --output-http staging.com")
+
+	flag.BoolVar(&Settings.inputRAWTrackResponse, "input-raw-track-response", false, "If turned on Gor will track responses in addition to requests, and they will be available to middleware and file output.")
 
 	flag.StringVar(&Settings.inputRAWEngine, "input-raw-engine", "libpcap", "Intercept traffic using `libpcap` (default), and `raw_socket`")
 

--- a/settings.go
+++ b/settings.go
@@ -41,8 +41,8 @@ type AppSettings struct {
 	inputFile  MultiOption
 	outputFile MultiOption
 
-	inputRAW       MultiOption
-	inputRAWEngine string
+	inputRAW              MultiOption
+	inputRAWEngine        string
 	inputRAWTrackResponse bool
 
 	middleware string


### PR DESCRIPTION
Not all cases require response information, so now they are optional, and turned off by default. 

Added new `--input-raw-track-response` option.

Should fix #276 