### PR TITLE
Rename --output-dummy to --output-stdout and make it boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Download latest binary from https://github.com/buger/gor/releases or (compile by
 
 ## Getting started
 
-The most basic setup will be `sudo ./gor --input-raw :8000 --output-dummy=""` which acts like tcpdump.
+The most basic setup will be `sudo ./gor --input-raw :8000 --output-stdout` which acts like tcpdump.
 If you already have test environment you can start replaying: `sudo ./gor --input-raw :8000 --output-http http://staging.env`.
 
 See the our wiki and especially [Getting started](https://github.com/buger/gor/wiki/Getting-Started) wiki page for more info. 

--- a/output_dummy.go
+++ b/output_dummy.go
@@ -9,14 +9,14 @@ type DummyOutput struct {
 }
 
 // NewDummyOutput constructor for DummyOutput
-func NewDummyOutput(options string) (di *DummyOutput) {
+func NewDummyOutput() (di *DummyOutput) {
 	di = new(DummyOutput)
 
 	return
 }
 
 func (i *DummyOutput) Write(data []byte) (int, error) {
-	fmt.Println("Writing message: ", string(data))
+	fmt.Println(string(data))
 
 	return len(data), nil
 }

--- a/plugins.go
+++ b/plugins.go
@@ -84,8 +84,12 @@ func InitPlugins() {
 		registerPlugin(NewDummyInput, options)
 	}
 
-	for _, options := range Settings.outputDummy {
-		registerPlugin(NewDummyOutput, options)
+	for range Settings.outputDummy {
+		registerPlugin(NewDummyOutput)
+	}
+
+	if Settings.outputStdout {
+		registerPlugin(NewDummyOutput)
 	}
 
 	engine := EnginePcap

--- a/settings.go
+++ b/settings.go
@@ -33,6 +33,7 @@ type AppSettings struct {
 
 	inputDummy  MultiOption
 	outputDummy MultiOption
+	outputStdout bool
 
 	inputTCP       MultiOption
 	outputTCP      MultiOption
@@ -73,7 +74,9 @@ func init() {
 	flag.BoolVar(&Settings.splitOutput, "split-output", false, "By default each output gets same traffic. If set to `true` it splits traffic equally among all outputs.")
 
 	flag.Var(&Settings.inputDummy, "input-dummy", "Used for testing outputs. Emits 'Get /' request every 1s")
-	flag.Var(&Settings.outputDummy, "output-dummy", "Used for testing inputs. Just prints data coming from inputs.")
+	flag.Var(&Settings.outputDummy, "output-dummy", "DEPRECATED: use --output-stdout instead")
+
+	flag.BoolVar(&Settings.outputStdout, "output-stdout", false, "Used for testing inputs. Just prints to console data coming from inputs.")
 
 	flag.Var(&Settings.inputTCP, "input-tcp", "Used for internal communication between Gor instances. Example: \n\t# Receive requests from other Gor instances on 28020 port, and redirect output to staging\n\tgor --input-tcp :28020 --output-http staging.com")
 	flag.Var(&Settings.outputTCP, "output-tcp", "Used for internal communication between Gor instances. Example: \n\t# Listen for requests on 80 port and forward them to other Gor instance on 28020 port\n\tgor --input-raw :80 --output-tcp replay.local:28020")


### PR DESCRIPTION
Currently it is quite confusing for dummy means, in addition it is not boolean variable, it require passing an argument (which does nothing).

Now you can just run gor like this:

```bash
gor —input-file ./requests —output-stdout
```