### PR TITLE
README: Fix link to issue tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ I also sell Gor Pro, extensions to Gor which provide more features, a commercial
 Subscribe to the [quarterly newsletter](https://tinyletter.com/gor) to stay informed about the latest features and changes to Gor and its bigger siblings.
 
 ## Problems?
-If you have a problem, please review the [FAQ](https://github.com/buger/gor/wiki/FAQ) and [Troubleshooting](https://github.com/buger/gor/wiki/Troubleshooting) wiki pages. Searching the (issues)[http://github.com/buger/gor] for your problem is also a good idea.
+If you have a problem, please review the [FAQ](https://github.com/buger/gor/wiki/FAQ) and [Troubleshooting](https://github.com/buger/gor/wiki/Troubleshooting) wiki pages. Searching the [issues](https://github.com/buger/gor/issues) for your problem is also a good idea.
 
 All bug-reports and suggestions should go though Github Issues or our [Google Group](https://groups.google.com/forum/#!forum/gor-users) (you can just send email to gor-users@googlegroups.com).
 If you have a private question feel free to send email to support@gortool.com.


### PR DESCRIPTION
It looks like you've used incorrect Markdown syntax to create a few links in commit eb9e073af850696bdf65ac2c13e5ec13b31ad0f7. You've since fixed some of the other links, e.g., in 2f86d005adbe8302c77071686c4d2f2792bafacd, but this one remained unfixed.

Also change the URL to point to issue tracker, and change the schema to https.

This is my first contribution to this repo, so let me know if something's off. I did not see a `CONTRIBUTING.md` file so I'm not following any special guidelines.