### PR TITLE
allow uncapitalized header fields

### DIFF
--- a/byteutils/byteutils.go
+++ b/byteutils/byteutils.go
@@ -38,3 +38,17 @@ func Replace(a []byte, from, to int, new []byte) []byte {
 		return a
 	}
 }
+
+// SwitchFirstCharCase changes the case of the first character in the array if
+// it is in a-zA-Z
+func SwitchFirstCharCase(a []byte) []byte {
+	if len(a) == 0 {
+		return a
+	}
+	if a[0] >= 97 && a[0] <= 122 {
+		a[0] -= 32
+	} else if a[0] >= 65 && a[0] <= 90 {
+		a[0] += 32
+	}
+	return a
+}

--- a/byteutils/byteutils_test.go
+++ b/byteutils/byteutils_test.go
@@ -30,3 +30,18 @@ func TestReplace(t *testing.T) {
 		t.Error("Should replace when replacement length bigger")
 	}
 }
+
+func TestSwitchFirstCharCase(t *testing.T) {
+	if !bytes.Equal([]byte("abc"), SwitchFirstCharCase([]byte("Abc"))) {
+		t.Error("Should uppercase first character")
+	}
+	if !bytes.Equal([]byte("Abc"), SwitchFirstCharCase([]byte("abc"))) {
+		t.Error("Should lowercase first character")
+	}
+	if !bytes.Equal([]byte("@bc"), SwitchFirstCharCase([]byte("@bc"))) {
+		t.Error("Should ignore first character if not in a-zA-Z")
+	}
+	if !bytes.Equal([]byte(""), SwitchFirstCharCase([]byte(""))) {
+		t.Error("Should do nothing if byte slice is empty")
+	}
+}

--- a/proto/proto.go
+++ b/proto/proto.go
@@ -77,11 +77,15 @@ func Header(payload, name []byte) []byte {
 // SetHeader sets header value. If header not found it creates new one.
 // Returns modified request payload
 func SetHeader(payload, name, value []byte) []byte {
-	_, hs, vs, he := header(payload, name)
+	// Try both "Header" and "header". If we find neither AddHeader with the original
+	for i := 0; i < 2; i++ {
+		_, hs, vs, he := header(payload, name)
 
-	if hs != -1 {
-		// If header found we just repace its value
-		return byteutils.Replace(payload, vs, he, value)
+		if hs != -1 {
+			// If header found we just repace its value
+			return byteutils.Replace(payload, vs, he, value)
+		}
+		byteutils.SwitchFirstCharCase(name)
 	}
 
 	return AddHeader(payload, name, value)

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -82,6 +82,13 @@ func TestSetHeader(t *testing.T) {
 	if payload = SetHeader(payload, []byte("User-Agent"), []byte("Gor")); !bytes.Equal(payload, payloadAfter) {
 		t.Error("Should add header if not found", string(payload))
 	}
+
+	payload = []byte("POST /post HTTP/1.1\r\nContent-Length: 7\r\nhost: www.w3.org\r\n\r\na=1&b=2")
+	payloadAfter = []byte("POST /post HTTP/1.1\r\nContent-Length: 14\r\nhost: www.example.com\r\n\r\na=1&b=2")
+
+	if payload = SetHeader(payload, []byte("Host"), []byte("www.example.com")); !bytes.Equal(payload, payloadAfter) {
+		t.Error("Should update header even if capitalization is wrong", string(payload))
+	}
 }
 
 func TestPath(t *testing.T) {


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7230#section-3.2
`
Each header field consists of a case-insensitive field name followed by a colon (":"), optional leading whitespace, the field value, and optional trailing whitespace.
`

So this is not completely correct, though accounting for `Header` and `header` should cover all but the most pathological cases. Accounting for all possible capitalizations will be much harder and slower (probably need to convert to a string and do a case insensitive regex) and doesn't seem worth it to me.