### PR TITLE
Add support for injecting real ip

### DIFF
--- a/gor.go
+++ b/gor.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
+	"net/http/httputil"
 	"os"
 	"os/signal"
 	"runtime"
@@ -14,8 +16,6 @@ import (
 	"runtime/pprof"
 	"syscall"
 	"time"
-	"net/http"
-	"net/http/httputil"
 )
 
 var (
@@ -25,11 +25,11 @@ var (
 )
 
 func loggingMiddleware(next http.Handler) http.Handler {
-  return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    rb, _ := httputil.DumpRequest(r, false)
-    log.Println(string(rb))
-    next.ServeHTTP(w, r)
-  })
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rb, _ := httputil.DumpRequest(r, false)
+		log.Println(string(rb))
+		next.ServeHTTP(w, r)
+	})
 }
 
 func main() {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -117,7 +117,7 @@ func TestEchoMiddleware(t *testing.T) {
 
 	// Catch traffic from one service
 	fromAddr := strings.Replace(from.Listener.Addr().String(), "[::]", "127.0.0.1", -1)
-	input := NewRAWInput(fromAddr, EnginePcap, true, testRawExpire)
+	input := NewRAWInput(fromAddr, EnginePcap, true, testRawExpire, "")
 	defer input.Close()
 
 	// And redirect to another
@@ -179,7 +179,7 @@ func TestTokenMiddleware(t *testing.T) {
 
 	fromAddr := strings.Replace(from.Listener.Addr().String(), "[::]", "127.0.0.1", -1)
 	// Catch traffic from one service
-	input := NewRAWInput(fromAddr, EnginePcap, true, testRawExpire)
+	input := NewRAWInput(fromAddr, EnginePcap, true, testRawExpire, "")
 	defer input.Close()
 
 	// And redirect to another

--- a/output_file.go
+++ b/output_file.go
@@ -104,19 +104,19 @@ func withoutIndex(s string) string {
 type sortByFileIndex []string
 
 func (s sortByFileIndex) Len() int {
-    return len(s)
+	return len(s)
 }
 
 func (s sortByFileIndex) Swap(i, j int) {
-    s[i], s[j] = s[j], s[i]
+	s[i], s[j] = s[j], s[i]
 }
 
 func (s sortByFileIndex) Less(i, j int) bool {
-    if withoutIndex(s[i]) == withoutIndex(s[j]) {
-    	return getFileIndex(s[i]) < getFileIndex(s[j])
-    }
+	if withoutIndex(s[i]) == withoutIndex(s[j]) {
+		return getFileIndex(s[i]) < getFileIndex(s[j])
+	}
 
-    return s[i] < s[j]
+	return s[i] < s[j]
 }
 
 func (o *FileOutput) filename() string {

--- a/output_file_test.go
+++ b/output_file_test.go
@@ -5,12 +5,12 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"reflect"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
-	"sort"
-	"reflect"
 )
 
 func TestFileOutput(t *testing.T) {

--- a/plugins.go
+++ b/plugins.go
@@ -101,7 +101,7 @@ func InitPlugins() {
 	}
 
 	for _, options := range Settings.inputRAW {
-		registerPlugin(NewRAWInput, options, engine, Settings.inputRAWTrackResponse, time.Duration(0))
+		registerPlugin(NewRAWInput, options, engine, Settings.inputRAWTrackResponse, time.Duration(0), Settings.inputRAWRealIPHeader)
 	}
 
 	for _, options := range Settings.inputTCP {

--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"strconv"
 	"time"
+	"net"
 )
 
 var _ = log.Println
@@ -266,4 +267,8 @@ func (t *TCPMessage) UpdateResponseAck() uint32 {
 
 func (t *TCPMessage) ID() tcpID {
 	return t.packets[0].ID
+}
+
+func (t *TCPMessage) IP() net.IP {
+	return net.IP(t.packets[0].Addr)
 }

--- a/settings.go
+++ b/settings.go
@@ -47,6 +47,7 @@ type AppSettings struct {
 	inputRAW              MultiOption
 	inputRAWEngine        string
 	inputRAWTrackResponse bool
+	inputRAWRealIPHeader  string
 
 	middleware string
 
@@ -101,6 +102,8 @@ func init() {
 	flag.BoolVar(&Settings.inputRAWTrackResponse, "input-raw-track-response", false, "If turned on Gor will track responses in addition to requests, and they will be available to middleware and file output.")
 
 	flag.StringVar(&Settings.inputRAWEngine, "input-raw-engine", "libpcap", "Intercept traffic using `libpcap` (default), and `raw_socket`")
+
+	flag.StringVar(&Settings.inputRAWRealIPHeader, "input-raw-realip-header", "", "If not blank, injects header with given name and real IP value to the request payload. Usually this header should be named: X-Real-IP")
 
 	flag.StringVar(&Settings.middleware, "middleware", "", "Used for modifying traffic using external command")
 


### PR DESCRIPTION
Added option `--input-raw-realip-header`, If not blank, injects header with given name and real IP value to the request payload. Usually, this header should be named: X-Real-IP, but you can specify different name. 

`gor --input-raw :80 --input-raw-realip-header "X-Real-IP" ...`