### PR TITLE
Clean current output file name

### DIFF
--- a/output_file.go
+++ b/output_file.go
@@ -11,8 +11,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 	"sync"
+	"time"
 )
 
 var dateFileNameFuncs = map[string]func() string{
@@ -170,7 +170,7 @@ func (o *FileOutput) filename() string {
 }
 
 func (o *FileOutput) updateName() {
-	o.currentName = o.filename()
+	o.currentName = filepath.Clean(o.filename())
 }
 
 func (o *FileOutput) Write(data []byte) (n int, err error) {

--- a/output_file_test.go
+++ b/output_file_test.go
@@ -53,6 +53,17 @@ func TestFileOutput(t *testing.T) {
 	close(quit)
 }
 
+func TestFileOutputWithNameCleaning(t *testing.T) {
+	output := &FileOutput{pathTemplate: "./test_requests.gor", config: &FileOutputConfig{flushInterval: time.Minute, append: false}}
+	expectedFileName := "test_requests_0.gor"
+	output.updateName()
+
+	if expectedFileName != output.currentName {
+		t.Errorf("Expected path %s but got %s", expectedFileName, output.currentName)
+	}
+
+}
+
 func TestFileOutputPathTemplate(t *testing.T) {
 	output := &FileOutput{pathTemplate: "/tmp/log-%Y-%m-%d-%S", config: &FileOutputConfig{flushInterval: time.Minute, append: true}}
 	now := time.Now()


### PR DESCRIPTION
This PR resolves a problem occurring when using the option `--output-file` with a path template which is not "clean" (for example, when containing `./`). 
This kind of "unclean" path template results in a loss of data in the output file because of a comparison between the name of the file currently open on the system and the marker of the file (`FileOutput.currentName`) we want to write in. This is explained in #303. 