### PR TITLE
Fix `Close` implementation of plugins

### DIFF
--- a/input_file.go
+++ b/input_file.go
@@ -189,6 +189,7 @@ func (i *FileInput) emit() {
 	log.Printf("FileInput: end of file '%s'\n", i.path)
 }
 
-func (i *FileInput) Close() {
+func (i *FileInput) Close() error {
 	i.currentFile.Close()
+	return nil
 }

--- a/input_raw.go
+++ b/input_raw.go
@@ -97,7 +97,8 @@ func (i *RAWInput) String() string {
 	return "Intercepting traffic from: " + i.address
 }
 
-func (i *RAWInput) Close() {
+func (i *RAWInput) Close() error {
 	i.listener.Close()
 	close(i.quit)
+	return nil
 }

--- a/output_file.go
+++ b/output_file.go
@@ -228,7 +228,7 @@ func (o *FileOutput) String() string {
 	return "File output: " + o.file.Name()
 }
 
-func (o *FileOutput) Close() {
+func (o *FileOutput) Close() error {
 	if o.file != nil {
 		if strings.HasSuffix(o.currentName, ".gz") {
 			o.writer.(*gzip.Writer).Close()
@@ -237,4 +237,5 @@ func (o *FileOutput) Close() {
 		}
 		o.file.Close()
 	}
+	return nil
 }


### PR DESCRIPTION
This PR fixes the implementation of `Close` functions in the plugins implementing it.
Indeed they do not declare error as return type and so, were not called at the end of the program when receiving the `SIGTERM` signal.