### PR TITLE
calculate TCP payload slice sizes for Ethernet II packets less than 64 octets

### DIFF
--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -397,9 +397,9 @@ func (t *Listener) readPcap() {
 
 					srcIP = data[12:16]
 					dstIP = data[16:20]
-					if len(packet.Data()) < 64 && decoder == layers.LinkTypeEthernet { // beware the runt frame https://en.wikipedia.org/wiki/Ethernet_frame#Runt_frames
-						sliceLen := len(packet.Data()) - (len(packet.Data()) - int(binary.BigEndian.Uint16(data[2:4])) - of) - of
-						data = data[ihl * 4: sliceLen]
+					// Stripping off the Ethernet envelope
+					if len(packet.Data()) <= 60 && decoder == layers.LinkTypeEthernet { // Ethernet envelope may have padding
+						data = data[ihl * 4: int(binary.BigEndian.Uint16(data[2:4]))]
 					} else {
 						data = data[ihl * 4:]
 					}

--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -397,7 +397,12 @@ func (t *Listener) readPcap() {
 
 					srcIP = data[12:16]
 					dstIP = data[16:20]
-					data = data[ihl*4:]
+					if len(packet.Data()) < 64 && decoder == layers.LinkTypeEthernet { // beware the runt frame https://en.wikipedia.org/wiki/Ethernet_frame#Runt_frames
+						sliceLen := len(packet.Data()) - (len(packet.Data()) - int(binary.BigEndian.Uint16(data[2:4])) - of) - of
+						data = data[ihl * 4: sliceLen]
+					} else {
+						data = data[ihl * 4:]
+					}
 				} else {
 					// Truncated IP info
 					if len(data) < 40 {

--- a/raw_socket_listener/listener.go
+++ b/raw_socket_listener/listener.go
@@ -397,8 +397,8 @@ func (t *Listener) readPcap() {
 
 					srcIP = data[12:16]
 					dstIP = data[16:20]
-					// Stripping off the Ethernet envelope
-					if len(packet.Data()) <= 60 && decoder == layers.LinkTypeEthernet { // Ethernet envelope may have padding
+					// Stripping off the IP header
+					if len(packet.Data()) <= 60 && decoder == layers.LinkTypeEthernet { // Small Ethernet packets have padding
 						data = data[ihl * 4: int(binary.BigEndian.Uint16(data[2:4]))]
 					} else {
 						data = data[ihl * 4:]

--- a/raw_socket_listener/tcp_message.go
+++ b/raw_socket_listener/tcp_message.go
@@ -171,7 +171,6 @@ func (t *TCPMessage) checkSeqIntegrity() {
 	t.seqMissing = false
 }
 
-var bCLRF = []byte("\r\n")
 var bEmptyLine = []byte("\r\n\r\n")
 var bChunkEnd = []byte("0\r\n\r\n")
 


### PR DESCRIPTION
Calculate TCP payload slice sizes for Ethernet II packets less than 64 octets and fix #325.