### PR TITLE
Fix Java middleware example

### DIFF
--- a/examples/middleware/echo.clj
+++ b/examples/middleware/echo.clj
@@ -1,0 +1,53 @@
+(ns echo.core
+  (:gen-class)
+  (:require [clojure.string :as cs]
+            [clojure.java.io :as io])
+  (:import org.apache.commons.codec.binary.Hex
+           java.io.BufferedReader
+           java.io.IOException
+           java.io.InputStreamReader))
+
+
+(defn transform-http-msg
+  "Function that transforms/filters the incoming HTTP messages."
+  [headers body]
+  ;; do actual transformations here
+  [headers body])
+
+
+(defn decode-hex-string
+  "Decode an Hex-encoded string."
+  [s]
+  (String. (Hex/decodeHex (.toCharArray s))))
+
+
+(defn encode-hex-string
+  "Encode a string to a hex-encoded string."
+  [^String s]
+  (String. (Hex/encodeHex (.getBytes s))))
+
+
+(defn -main
+  [& args]
+  (let [br (BufferedReader. (InputStreamReader. System/in))]
+    (try
+      (loop [hex-line (.readLine br)]
+        (let [decoded-req (decode-hex-string hex-line)
+
+              ;; empty line separates headers from body
+              http-request (partition-by empty? (cs/split-lines decoded-req))
+              headers (first http-request)
+
+              ;; HTTP messages can contain no body:
+              body (when (= 3 (count http-request)) (last http-request))
+              [new-headers new-body] (transform-http-msg headers body)]
+
+          (println (encode-hex-string (str (cs/join "\n" headers)
+                                           (when body
+                                             (str "\n\n"
+                                                  (cs/join "\n" body)))))))
+        (when-let [line (.readLine br)]
+          (recur line)))
+      (catch IOException e nil))))
+
+

--- a/examples/middleware/echo.java
+++ b/examples/middleware/echo.java
@@ -2,8 +2,25 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-public class echo {
-    public static void main(String[] args) {
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+
+
+public class Echo {
+        public static String decodeHexString(String s) throws DecoderException {
+            return new String(Hex.decodeHex(s.toCharArray()));
+        }
+
+        public static String encodeHexString(String s) {
+            return new String(Hex.encodeHex(s.getBytes()));
+        }
+
+        public static String transformHTTPMessage(String req) {
+            // do actual transformations here
+            return req;
+        }
+
+    public static void main(String[] args) throws DecoderException {
         if(args != null){
             for(String arg : args){
                 System.out.println(arg);
@@ -17,8 +34,12 @@ public class echo {
 
         try {
             while ((line = stdin.readLine()) != null) {
+                String decodedLine = decodeHexString(line);
 
-                System.out.println(line);
+                String transformedLine = transformHTTPMessage(decodedLine);
+
+                String encodedLine = encodeHexString(transformedLine);
+                System.out.println(encodedLine);
 
             }
         } catch (IOException e) {


### PR DESCRIPTION
The Java middleware example did not handle encoding/decoding of HTTP messages sent to the middleware -- fixed that.
Added a Clojure middleware example as well.