### PR TITLE
Add google/gopacket in vendor/

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "vendor/github.com/bmizerany/assert"]
 	path = vendor/github.com/bmizerany/assert
 	url = https://github.com/bmizerany/assert
+[submodule "vendor/github.com/google/gopacket"]
+	path = vendor/github.com/google/gopacket
+	url = https://github.com/google/gopacket


### PR DESCRIPTION
Hey @buger,

As discussed on gor-users@googlegroups.com, here is a small contribution to add google/gopacket in the vendor directory, just like all other Gor dependencies.