### PR TITLE
Set default value for output-http-timeout at declaration

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -64,10 +64,6 @@ func NewHTTPClient(baseURL string, config *HTTPClientConfig) *HTTPClient {
 		}
 	}
 
-	if config.Timeout.Nanoseconds() == 0 {
-		config.Timeout = 5 * time.Second
-	}
-
 	config.ConnectionTimeout = config.Timeout
 
 	if config.ResponseBufferSize == 0 {

--- a/settings.go
+++ b/settings.go
@@ -118,7 +118,7 @@ func init() {
 	flag.IntVar(&Settings.outputHTTPConfig.BufferSize, "output-http-response-buffer", 0, "HTTP response buffer size, all data after this size will be discarded.")
 	flag.IntVar(&Settings.outputHTTPConfig.workers, "output-http-workers", 0, "Gor uses dynamic worker scaling by default.  Enter a number to run a set number of workers.")
 	flag.IntVar(&Settings.outputHTTPConfig.redirectLimit, "output-http-redirects", 0, "Enable how often redirects should be followed.")
-	flag.DurationVar(&Settings.outputHTTPConfig.Timeout, "output-http-timeout", 0, "Specify HTTP request/response timeout. By default 5s. Example: --output-http-timeout 30s")
+	flag.DurationVar(&Settings.outputHTTPConfig.Timeout, "output-http-timeout", 5 * time.Second, "Specify HTTP request/response timeout. By default 5s. Example: --output-http-timeout 30s")
 
 	flag.BoolVar(&Settings.outputHTTPConfig.stats, "output-http-stats", false, "Report http output queue stats to console every 5 seconds.")
 	flag.BoolVar(&Settings.outputHTTPConfig.OriginalHost, "http-original-host", false, "Normally gor replaces the Host http header with the host supplied with --output-http.  This option disables that behavior, preserving the original Host header.")


### PR DESCRIPTION
The actual default is 5s, set in the call of NewHTTPClient,
even if we use `--output-http--timeout=0`.

It's clearer to user if this value id declared upfront.