### PR TITLE
Add basic SNI support

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -89,7 +89,7 @@ func (c *HTTPClient) Connect() (err error) {
 	}
 
 	if c.scheme == "https" {
-		tlsConn := tls.Client(c.conn, &tls.Config{InsecureSkipVerify: true})
+		tlsConn := tls.Client(c.conn, &tls.Config{InsecureSkipVerify: true, ServerName: c.host})
 
 		if err = tlsConn.Handshake(); err != nil {
 			return


### PR DESCRIPTION
By adding the server name as part of the TLS client configuration, gor
will now support connecting to hosts that require SNI (such as Amazon
API Gateway).