### PR TITLE
Resolve buger/gor#394 : Timeout for NO_CONTENT responses

### DIFF
--- a/http_client.go
+++ b/http_client.go
@@ -207,9 +207,14 @@ func (c *HTTPClient) Send(data []byte) (response []byte, err error) {
 					if bytes.Equal(proto.Header(c.respBuf, []byte("Transfer-Encoding")), []byte("chunked")) {
 						chunked = true
 					} else {
-						l := proto.Header(c.respBuf, []byte("Content-Length"))
-						if len(l) > 0 {
-							contentLength, _ = strconv.Atoi(string(l))
+						status, _ := strconv.Atoi(string(proto.Status(c.respBuf)))
+						if (status >= 100 && status < 200) || status == 204 || status == 304 {
+							contentLength = 0
+						} else {
+							l := proto.Header(c.respBuf, []byte("Content-Length"))
+							if len(l) > 0 {
+								contentLength, _ = strconv.Atoi(string(l))
+							}
 						}
 					}
 


### PR DESCRIPTION
1xx, 204 and 304 HTTP responses MUST NOT include a message body (see [RFC-2616](https://tools.ietf.org/html/rfc2616#section-4.4)).
Also, a server MAY send a Content-Length header field in a 304 (Not Modified) and MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content) (see [RFC-7230](https://tools.ietf.org/html/rfc7230#section-3.3.2))