### PR TITLE
Register kafka output plugin in case of having passed settings

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -143,5 +143,7 @@ func InitPlugins() {
 		registerPlugin(NewHTTPOutput, options, &Settings.outputHTTPConfig)
 	}
 
-	registerPlugin(NewKafkaOutput, "", &Settings.outputKafkaConfig)
+	if Settings.outputKafkaConfig.host != "" && Settings.outputKafkaConfig.topic != "" {
+		registerPlugin(NewKafkaOutput, "", &Settings.outputKafkaConfig)
+	}
 }


### PR DESCRIPTION
Hi @buger 

In kafka output plugin I did mistake on creating the publisher instance all the time despite on passed settings.

Would it be enough to have only `if` condition?

[issue](https://github.com/buger/gor/issues/397)

Thank you!